### PR TITLE
faster duplicate filtering via hashes of the config dict

### DIFF
--- a/seml/database_utils.py
+++ b/seml/database_utils.py
@@ -316,3 +316,19 @@ def chunk_list(exps):
         size = exps[idx[0]]['slurm']['experiments_per_job']
         exp_chunks.extend(([exps[i] for i in idx[pos:pos + size]] for pos in range(0, len(idx), size)))
     return exp_chunks
+
+
+def make_hash(d: dict):
+    """
+    Generate a hash for the input dictionary.
+    From: https://stackoverflow.com/a/22003440
+    Parameters
+    ----------
+    d: input dictionary
+
+    Returns
+    -------
+    hash (hex encoded) of the input dictionary.
+    """
+    import hashlib
+    return hashlib.md5(json.dumps(d, sort_keys=True).encode("utf-8")).hexdigest()

--- a/seml/main.py
+++ b/seml/main.py
@@ -302,6 +302,11 @@ if __name__ == '__main__':
             "queue",
             help="Queue the experiments as defined in the configuration.")
     parser_queue.add_argument(
+            '-n', '--no-hash', action='store_true',
+            help="If True, will not use the hash of the config dictionary to filter out duplicates (by comparing all"
+                 "dictionary values individually. This is much  slower, so use only if you have a good reason not to"
+                 " use the hash.")
+    parser_queue.add_argument(
             '-f', '--force-duplicates', action='store_true',
             help="If True, will add experiments to the database even when experiments with identical configurations "
                  "are already in the database.")

--- a/seml/queue_experiments.py
+++ b/seml/queue_experiments.py
@@ -171,7 +171,7 @@ def generate_configs(experiment_config):
     return all_configs
 
 
-def filter_experiments(collection, configurations, no_hash=False):
+def filter_experiments(collection, configurations, use_hash=False):
     """Check database collection for already present entries.
 
     Check the database collection for experiments that have the same configuration.
@@ -184,8 +184,8 @@ def filter_experiments(collection, configurations, no_hash=False):
         The MongoDB collection containing the experiments.
     configurations: list of dicts
         Contains the individual parameter configurations.
-    no_hash: bool (default: False)
-        Whether to *NOT* use the hash of the config dictionary to perform a faster duplicate check.
+    use_hash: bool (default: False)
+        Whether to use the hash of the config dictionary to perform a faster duplicate check.
 
     Returns
     -------
@@ -196,7 +196,7 @@ def filter_experiments(collection, configurations, no_hash=False):
 
     filtered_configs = []
     for config in tqdm(configurations):
-        if not no_hash:
+        if use_hash:
             config_hash = make_hash(config)
             lookup_result = collection.find_one({'config_hash': config_hash})
         else:
@@ -281,7 +281,8 @@ def queue_experiments(config_file, force_duplicates, no_hash=False):
 
     if not force_duplicates:
         len_before = len(configs)
-        configs = filter_experiments(collection, configs, no_hash=no_hash)
+        use_hash = not no_hash
+        configs = filter_experiments(collection, configs, use_hash=use_hash)
         len_after = len(configs)
         if len_after != len_before:
             print(f"{len_before - len_after} of {len_before} experiment{s_if(len_before)} were already found "


### PR DESCRIPTION
### What does this implement/fix?
Computes a hash value of the config dict using Python's `hashlib` to store in each experiment entry. Creates an index over `config_hash` to enable fast search while scanning for duplicates.