### PR TITLE
Update jsonpickle requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pymongo>=3.7
 pandas
 sacred
 pyyaml
-jsonpickle>=0.7.2, <1.0
+jsonpickle>=1.2, <2.0
 munch>=2.0.4


### PR DESCRIPTION
The old requirement for `jsonpickle` does not include `jsonpickle.ext.pandas` which is requries by the latest version of `sacred`.
Also the latest version of `sacred` requires `jsonpickle` to be `<2.0,>=1.2`.