### PR TITLE
Upload files when queueing

### DIFF
--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -58,7 +58,7 @@ slurm:
   name: example_experiment
   experiments_per_job: 1
   sbatch_options:
-    gres: gpu:0       # num GPUs
+    gres: gpu:1       # num GPUs
     mem: 16G          # memory
     cpus-per-task: 1  # num cores
     time: 0-08:00     # max time, D-HH:MM

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -6,6 +6,10 @@
 # executable:    Name of the Python script containing the experiment
 # It can optionally also contain the following values:
 # conda_environment: Specifies which conda environment will be activated before the experiment is executed.
+# project_root_dir: (relative or absolute) path to the root of the project. seml will then upload all the source
+#                   files imported by the experiment to the MongoDB. Moreover, the uploaded source files will be
+#                   downloaded before starting an experiment, so any changes to the source files in the project
+#                   between queueing and starting the experiment will have no effect.
 # output_dir:    Directory to store log files in. Default: Current directory
 #
 # The special 'slurm' block contains the slurm parameters. This block and all values are optional. Possible values are:
@@ -48,12 +52,13 @@ seml:
   db_collection: example_experiment
   executable: example_experiment.py
   output_dir: slurm
+  project_root_dir: ..
 
 slurm:
   name: example_experiment
   experiments_per_job: 1
   sbatch_options:
-    gres: gpu:1       # num GPUs
+    gres: gpu:0       # num GPUs
     mem: 16G          # memory
     cpus-per-task: 1  # num cores
     time: 0-08:00     # max time, D-HH:MM

--- a/examples/example_experiment.py
+++ b/examples/example_experiment.py
@@ -28,7 +28,7 @@ def run(dataset, hidden_sizes, learning_rate, reg_scale, keep_prob, max_epochs, 
 
     logging.info('Received the following configuration:')
     logging.info(f'Dataset: {dataset}, hidden sizes: {hidden_sizes}, learning_rate: {learning_rate},'
-                 f'reg_scale: {reg_scale}, keep_prob:{keep_prob}, max_epochs: {max_epochs}, patience:{patience}'
+                 f'reg_scale: {reg_scale}, keep_prob:{keep_prob}, max_epochs: {max_epochs}, patience:{patience},'
                  f'display_step: {display_step}, regularization: {regularization_params}')
 
     #  do your processing here

--- a/examples/example_experiment.py
+++ b/examples/example_experiment.py
@@ -23,12 +23,13 @@ def config():
 
 
 @ex.automain
-def run(dataset, hidden_sizes, learning_rate, reg_scale, keep_prob, max_epochs, patience, display_step, regularization_params):
+def run(dataset, hidden_sizes, learning_rate, reg_scale, keep_prob, max_epochs, patience, display_step,
+        regularization_params):
 
     logging.info('Received the following configuration:')
     logging.info(f'Dataset: {dataset}, hidden sizes: {hidden_sizes}, learning_rate: {learning_rate},'
-                 f'reg_scale: {reg_scale}, keep_prob:{keep_prob}, max_epochs: {max_epochs}, patience:{patience}, '
-                 f'display_step: {display_step}')
+                 f'reg_scale: {reg_scale}, keep_prob:{keep_prob}, max_epochs: {max_epochs}, patience:{patience}'
+                 f'display_step: {display_step}, regularization: {regularization_params}')
 
     #  do your processing here
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sacred>=0.8.1
 pyyaml
 jsonpickle>=1.2, <2.0
 munch>=2.0.4
+gitpython

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ sacred>=0.8.1
 pyyaml
 jsonpickle>=1.2, <2.0
 munch>=2.0.4
-gitpython

--- a/seml/database_utils.py
+++ b/seml/database_utils.py
@@ -363,7 +363,18 @@ def make_hash(d: dict):
     return hashlib.md5(json.dumps(d, sort_keys=True).encode("utf-8")).hexdigest()
 
 
-def get_max_value(collection, field):
+def get_max_value(collection: Collection, field: str):
+    """
+    Find the maximum value in the input collection for the input field.
+    Parameters
+    ----------
+    collection
+    field
+
+    Returns
+    -------
+    max_val: the maximum value in the field.
+    """
 
     ndocs = collection.count_documents({})
     if field == "_id":
@@ -381,6 +392,18 @@ def get_max_value(collection, field):
 
 
 def upload_source_file(filename, db_collection: Collection, batch_id):
+    """
+    Upload a source file to the MongoDB.
+    Parameters
+    ----------
+    filename: str
+    db_collection: Collection
+    batch_id: int
+
+    Returns
+    -------
+    file_id: ID of the inserted file, or None if there was an error.
+    """
     db = db_collection.database
     fs = gridfs.GridFS(db)
     try:
@@ -395,3 +418,4 @@ def upload_source_file(filename, db_collection: Collection, batch_id):
     except IOError:
         print(f"IOError: could not read {filename}")
     return None
+

--- a/seml/database_utils.py
+++ b/seml/database_utils.py
@@ -1,4 +1,6 @@
 import os
+
+import gridfs
 from pymongo import MongoClient
 import numpy as np
 import yaml
@@ -7,8 +9,13 @@ import jsonpickle
 from bson import json_util
 import warnings
 import ast
+
+from pymongo.collection import Collection
+
 from seml.settings import SETTINGS
 import urllib.parse
+import pymongo
+
 try:
     from tqdm.autonotebook import tqdm
 except ImportError:
@@ -354,3 +361,37 @@ def make_hash(d: dict):
     """
     import hashlib
     return hashlib.md5(json.dumps(d, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def get_max_value(collection, field):
+
+    ndocs = collection.count_documents({})
+    if field == "_id":
+        c = collection.find({}, {'_id': 1})
+    else:
+        c = collection.find({}, {'_id': 1, field: 1})
+    b = c.sort(field, pymongo.DESCENDING).limit(1)
+    if ndocs != 0:
+        b_next = b.next()
+        max_val = b_next[field] if field in b_next else None
+    else:
+        max_val = None
+
+    return max_val
+
+
+def upload_source_file(filename, db_collection: Collection, batch_id):
+    db = db_collection.database
+    fs = gridfs.GridFS(db)
+    try:
+        with open(filename, "rb") as f:
+            db_filename = f"file://{db_collection.name}/{batch_id}/{filename}"
+            file_id = fs.put(
+                f, filename=db_filename, metadata={"collection_name": db_collection.name,
+                                                   "type": "source_file",
+                                                   "batch_id": batch_id}
+            )
+            return file_id
+    except IOError:
+        print(f"IOError: could not read {filename}")
+    return None

--- a/seml/database_utils.py
+++ b/seml/database_utils.py
@@ -424,7 +424,9 @@ def load_sources_from_db(exp, to_directory):
     collection = get_collection(exp['seml']['db_collection'])
     db = collection.database
     fs = gridfs.GridFS(db)
-    source_files = exp['source_files']
+    if not 'source_files' in exp['seml']:
+        raise ValueError(f'No source files found for experiment with ID {exp["_id"]}')
+    source_files = exp['seml']['source_files']
     for path, _id in source_files:
         _dir = f"{to_directory}/{os.path.dirname(path)}"
         if not os.path.exists(_dir):

--- a/seml/database_utils.py
+++ b/seml/database_utils.py
@@ -9,6 +9,7 @@ import jsonpickle
 from bson import json_util
 import warnings
 import ast
+import logging
 
 from pymongo.collection import Collection
 
@@ -416,7 +417,7 @@ def upload_source_file(filename, db_collection: Collection, batch_id):
             )
             return file_id
     except IOError:
-        print(f"IOError: could not read {filename}")
+        logging.error(f"IOError: could not read {filename}")
     return None
 
 

--- a/seml/get_experiment_command.py
+++ b/seml/get_experiment_command.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         db = collection.database
         fs = gridfs.GridFS(db)
         source_files = exp['source_files']
-        for _id, path in source_files:
+        for path, _id in source_files:
             _dir = f"{args.stored_sources_dir}/{os.path.dirname(path)}"
             if not os.path.exists(_dir):
                 os.makedirs(_dir)

--- a/seml/get_experiment_command.py
+++ b/seml/get_experiment_command.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     exp = collection.find_one({'_id': exp_id})
     use_stored_sources = args.stored_sources_dir is not None
     if use_stored_sources:
-        assert "source_files" in exp, \
+        assert "source_files" in exp['seml'], \
             "--stored-sources-dir was supplied but queued experiment does not contain stored source files."
         db_utils.load_sources_from_db(exp, to_directory=args.stored_sources_dir)
 

--- a/seml/get_experiment_command.py
+++ b/seml/get_experiment_command.py
@@ -1,6 +1,9 @@
 import argparse
 from seml import database_utils as db_utils
 from seml.misc import get_config_from_exp
+import gridfs
+import os
+import numpy as np
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -13,6 +16,7 @@ if __name__ == "__main__":
     parser.add_argument("--log-verbose", default=False, type=lambda x: (str(x).lower() == 'true'), help="Display more log messages.")
     parser.add_argument("--unobserved", default=False, type=lambda x: (str(x).lower() == 'true'), help="Run the experiments without Sacred observers.")
     parser.add_argument("--post-mortem", default=False, type=lambda x: (str(x).lower() == 'true'), help="Activate post-mortem debugging with pdb.")
+    parser.add_argument("--stored-sources-dir", default=None, type=str, help="Load source files into this directory before starting.")
     args = parser.parse_args()
 
     exp_id = args.experiment_id
@@ -21,14 +25,38 @@ if __name__ == "__main__":
     collection = db_utils.get_collection(db_collection)
 
     exp = collection.find_one({'_id': exp_id})
+    relative = args.stored_sources_dir is not None
+    if relative:
+        assert "source_files" in exp, \
+            "--stored-sources-dir was supplied but queued experiment does not contain stored source files."
+
+        db = collection.database
+        fs = gridfs.GridFS(db)
+        source_files = exp['source_files']
+        for _id, path in source_files:
+            _dir = f"{args.stored_sources_dir}/{os.path.dirname(path)}"
+            if not os.path.exists(_dir):
+                os.makedirs(_dir)
+            with open(f'{args.stored_sources_dir}/{path}', 'wb') as f:
+                f.write(fs.find_one(_id).read())
 
     exe, config = get_config_from_exp(exp, log_verbose=args.log_verbose,
-                                      unobserved=args.unobserved, post_mortem=args.post_mortem)
-    cmd = f"python {exe} with {' '.join(config)}"
+                                      unobserved=args.unobserved, post_mortem=args.post_mortem,
+                                      relative=relative)
 
-    collection.update_one(
+    cmd = f"python {exe} with {' '.join(config)}"
+    if relative:
+        # add command without the temp_dir prefix
+        # also add the temp dir for debugging purposes
+        collection.update_one(
             {'_id': exp_id},
-            {'$set': {'seml.command': cmd}})
+            {'$set': {'seml.command': cmd, 'seml.temp_dir': args.stored_sources_dir}})
+        # add the temp_dir prefix to the command
+        cmd = f"python {args.stored_sources_dir}/{exe} with {' '.join(config)}"
+    else:
+        collection.update_one(
+                {'_id': exp_id},
+                {'$set': {'seml.command': cmd}})
 
     if exp is None:
         exit(2)

--- a/seml/main.py
+++ b/seml/main.py
@@ -180,7 +180,7 @@ def reset_experiment(collection, exp):
     keep_entries = ['batch_id', 'status', 'seml', 'slurm', 'config', 'config_hash', 'queue_time']
 
     # Clean up SEML dictionary
-    keep_seml = {'db_collection', 'executable', 'conda_environment', 'output_dir', 'source_files'}
+    keep_seml = {'db_collection', 'executable', 'conda_environment', 'output_dir', 'source_files', 'project_root_dir'}
     seml_keys = set(exp['seml'].keys())
     for key in seml_keys - keep_seml:
         del exp['seml'][key]

--- a/seml/main.py
+++ b/seml/main.py
@@ -179,7 +179,7 @@ def reset_experiment(collection, exp):
     keep_entries = ['batch_id', 'status', 'seml', 'slurm', 'config', 'config_hash', 'queue_time']
 
     # Clean up SEML dictionary
-    keep_seml = {'db_collection', 'executable', 'conda_environment', 'output_dir'}
+    keep_seml = {'db_collection', 'executable', 'conda_environment', 'output_dir', 'source_files'}
     seml_keys = set(exp['seml'].keys())
     for key in seml_keys - keep_seml:
         del exp['seml'][key]

--- a/seml/main.py
+++ b/seml/main.py
@@ -15,6 +15,7 @@ except ImportError:
     def tqdm(iterable, total=None):
         return iterable
 
+
 def report_status(config_file):
     detect_killed(config_file, verbose=False)
     collection = db_utils.get_collection_from_config(config_file)

--- a/seml/queue_experiments.py
+++ b/seml/queue_experiments.py
@@ -252,6 +252,8 @@ def queue_configs(collection, seml_config, slurm_config, configs, source_files=N
 
     print(f"Queueing {len(configs)} configs into the database (batch-ID {batch_id}).")
 
+    if source_files is not None:
+        seml_config['source_files'] = source_files
     db_dicts = [{'_id': start_id + ix,
                  'batch_id': batch_id,
                  'status': 'QUEUED',
@@ -261,8 +263,7 @@ def queue_configs(collection, seml_config, slurm_config, configs, source_files=N
                  'config_hash': make_hash(c),
                  'queue_time': datetime.datetime.utcnow()}
                 for ix, c in enumerate(configs)]
-    if source_files is not None:
-        db_dicts = [{**d, 'source_files': source_files} for d in db_dicts]
+
     collection.insert_many(db_dicts)
 
 

--- a/seml/queue_experiments.py
+++ b/seml/queue_experiments.py
@@ -367,7 +367,7 @@ def queue_experiments(config_file, force_duplicates, no_hash=False, no_config_ch
     else:
         batch_id = batch_id + 1
 
-    if "project_root_dir" in seml_config:
+    if "project_root_dir" not in seml_config:
         print("Warning: 'project_root_dir' not defined in seml config. Source files will not be uploaded.")
         uploaded_files = None
     else:
@@ -407,3 +407,4 @@ def upload_sources(seml_config, collection, batch_id):
         file_id = upload_source_file(s, collection, batch_id)
         source_path = Path(s)
         uploaded_files.append((str(source_path.relative_to(root_dir)), file_id))
+    return uploaded_files

--- a/seml/queue_experiments.py
+++ b/seml/queue_experiments.py
@@ -4,10 +4,12 @@ import datetime
 import numpy as np
 import pymongo
 
-from seml.database_utils import make_hash
+from seml.database_utils import make_hash, upload_source_file
 from seml import parameter_utils as utils
 from seml import database_utils as db_utils
-from seml.misc import get_default_slurm_config, s_if, unflatten, flatten, import_exe
+from seml.misc import get_default_slurm_config, s_if, unflatten, flatten, import_exe, is_local_source
+
+from pathlib import Path
 
 
 def unpack_config(config):
@@ -210,7 +212,7 @@ def filter_experiments(collection, configurations, use_hash=True):
     return filtered_configs
 
 
-def queue_configs(collection, seml_config, slurm_config, configs):
+def queue_configs(collection, seml_config, slurm_config, configs, source_files=None):
     """Put the input configurations into the database.
 
     Parameters
@@ -223,6 +225,9 @@ def queue_configs(collection, seml_config, slurm_config, configs):
         Settings for the Slurm job. See `start_experiments.start_slurm_job` for details.
     configs: list of dicts
         Contains the parameter configurations.
+    source_files: (optional) list of tuples
+        Contains the uploaded source files corresponding to the batch. Entries are of the form
+        (object_id, relative_path)
 
     Returns
     -------
@@ -233,18 +238,17 @@ def queue_configs(collection, seml_config, slurm_config, configs):
     if len(configs) == 0:
         return
 
-    ndocs = collection.count_documents({})
-    c = collection.find({}, {'_id': 1, 'batch_id': 1})
-    c = c.sort('_id', pymongo.DESCENDING).limit(1)
-    start_id = c.next()['_id'] + 1 if ndocs != 0 else 1
-    c.rewind()
-    b = c.sort('batch_id', pymongo.DESCENDING).limit(1)
-
-    if ndocs != 0:
-        b_next = b.next()
-        batch_id = b_next['batch_id'] + 1 if "batch_id" in b_next else 1
+    start_id = db_utils.get_max_value(collection, "_id")
+    if start_id is None:
+        start_id = 1
     else:
+        start_id = start_id + 1
+
+    batch_id = db_utils.get_max_value(collection, "batch_id")
+    if batch_id is None:
         batch_id = 1
+    else:
+        batch_id = batch_id + 1
 
     print(f"Queueing {len(configs)} configs into the database (batch-ID {batch_id}).")
 
@@ -257,7 +261,32 @@ def queue_configs(collection, seml_config, slurm_config, configs):
                  'config_hash': make_hash(c),
                  'queue_time': datetime.datetime.utcnow()}
                 for ix, c in enumerate(configs)]
+    if source_files is not None:
+        db_dicts = [{**d, 'source_files': source_files} for d in db_dicts]
     collection.insert_many(db_dicts)
+
+
+def get_imported_files(executable, root_dir="../"):
+    MODULE_BLACKLIST = set()
+    exe_path = os.path.abspath(executable)
+    sys.path.insert(0, os.path.dirname(exe_path))
+    exp_module = importlib.import_module(os.path.splitext(os.path.basename(executable))[0])
+    del sys.path[0]
+    root_path = os.path.abspath(root_dir)
+
+    sources = set()
+    for name, mod in sys.modules.items():
+        if name in MODULE_BLACKLIST:
+            continue
+        if mod is None:
+            continue
+        if not getattr(mod, "__file__", False):
+            continue
+        filename = os.path.abspath(mod.__file__)
+        if filename not in sources and is_local_source(filename, root_path):
+            sources.add(filename)
+
+    return sources
 
 
 def check_sacred_config(executable, conda_env, configs):
@@ -315,7 +344,7 @@ def queue_experiments(config_file, force_duplicates, no_hash=False, no_config_ch
     seml_config, slurm_config, experiment_config = db_utils.read_config(config_file)
 
     # Use current Anaconda environment if not specified
-    if 'conda_environment' not in seml_config:
+    if 'conda_environment' not in seml_config and 'CONDA_DEFAULT_ENV' in os.environ:
         seml_config['conda_environment'] = os.environ['CONDA_DEFAULT_ENV']
 
     # Set Slurm config with default parameters as fall-back option
@@ -331,6 +360,27 @@ def queue_experiments(config_file, force_duplicates, no_hash=False, no_config_ch
     slurm_config['sbatch_options'] = utils.remove_dashes(slurm_config['sbatch_options'])
     collection = db_utils.get_collection(seml_config['db_collection'])
     configs = generate_configs(experiment_config)
+
+    root_dir = os.path.abspath("../")
+    sources = get_imported_files(seml_config['executable'], root_dir=root_dir)
+    executable_abs = os.path.abspath(seml_config['executable'])
+    executable_rel = Path(executable_abs).relative_to(root_dir)
+
+    if not executable_abs in sources:
+        raise ValueError(f"Executable {executable_abs} was not found in the sources to upload.")
+    seml_config['executable_relative'] = str(executable_rel)
+
+    batch_id = db_utils.get_max_value(collection, "batch_id")
+    if batch_id is None:
+        batch_id = 1
+    else:
+        batch_id = batch_id + 1
+
+    uploaded_files = []
+    for s in sources:
+        file_id = upload_source_file(s, collection, batch_id)
+        source_path = Path(s)
+        uploaded_files.append((str(source_path.relative_to(root_dir)), file_id))
 
     if not no_config_check:
         check_sacred_config(seml_config['executable'], seml_config['conda_environment'], configs)
@@ -348,4 +398,4 @@ def queue_experiments(config_file, force_duplicates, no_hash=False, no_config_ch
     collection.create_index("config_hash")
     # Add the configurations to the database with QUEUED status.
     if len(configs) > 0:
-        queue_configs(collection, seml_config, slurm_config, configs)
+        queue_configs(collection, seml_config, slurm_config, configs, uploaded_files)

--- a/seml/queue_experiments.py
+++ b/seml/queue_experiments.py
@@ -270,11 +270,8 @@ def queue_configs(collection, seml_config, slurm_config, configs, source_files=N
     collection.insert_many(db_dicts)
 
 
-def get_imported_files(executable, root_dir):
-    exe_path = os.path.abspath(executable)
-    sys.path.insert(0, os.path.dirname(exe_path))
-    exp_module = importlib.import_module(os.path.splitext(os.path.basename(executable))[0])
-    del sys.path[0]
+def get_imported_files(executable, root_dir, conda_env):
+    exp_module = import_exe(executable, conda_env)
     root_path = os.path.abspath(root_dir)
 
     sources = set()
@@ -395,7 +392,8 @@ def queue_experiments(config_file, force_duplicates, no_hash=False, no_config_ch
 
 def upload_sources(seml_config, collection, batch_id):
     root_dir = os.path.abspath(os.path.expanduser(seml_config['project_root_dir']))
-    sources = get_imported_files(seml_config['executable'], root_dir=root_dir)
+    sources = get_imported_files(seml_config['executable'], root_dir=root_dir,
+                                 conda_env=seml_config['conda_environment'])
     executable_abs = os.path.abspath(seml_config['executable'])
     executable_rel = Path(executable_abs).relative_to(root_dir)
 

--- a/seml/queue_experiments.py
+++ b/seml/queue_experiments.py
@@ -369,7 +369,7 @@ def queue_experiments(config_file, force_duplicates, no_hash=False, no_config_ch
         batch_id = batch_id + 1
 
     if "project_root_dir" not in seml_config:
-        logging.warning("Warning: 'project_root_dir' not defined in seml config. Source files will not be uploaded.")
+        logging.warning("'project_root_dir' not defined in seml config. Source files will not be uploaded.")
         uploaded_files = None
     else:
         uploaded_files = upload_sources(seml_config, collection, batch_id)

--- a/seml/queue_experiments.py
+++ b/seml/queue_experiments.py
@@ -269,7 +269,7 @@ def queue_configs(collection, seml_config, slurm_config, configs, source_files=N
     collection.insert_many(db_dicts)
 
 
-def get_imported_files(executable, root_dir="../"):
+def get_imported_files(executable, root_dir):
     exe_path = os.path.abspath(executable)
     sys.path.insert(0, os.path.dirname(exe_path))
     exp_module = importlib.import_module(os.path.splitext(os.path.basename(executable))[0])

--- a/seml/queue_experiments.py
+++ b/seml/queue_experiments.py
@@ -3,13 +3,15 @@ import sys
 import datetime
 import numpy as np
 import pymongo
+import importlib
+import sys
+from pathlib import Path
 
 from seml.database_utils import make_hash, upload_source_file
 from seml import parameter_utils as utils
 from seml import database_utils as db_utils
 from seml.misc import get_default_slurm_config, s_if, unflatten, flatten, import_exe, is_local_source
 
-from pathlib import Path
 
 
 def unpack_config(config):
@@ -268,7 +270,6 @@ def queue_configs(collection, seml_config, slurm_config, configs, source_files=N
 
 
 def get_imported_files(executable, root_dir="../"):
-    MODULE_BLACKLIST = set()
     exe_path = os.path.abspath(executable)
     sys.path.insert(0, os.path.dirname(exe_path))
     exp_module = importlib.import_module(os.path.splitext(os.path.basename(executable))[0])
@@ -277,8 +278,6 @@ def get_imported_files(executable, root_dir="../"):
 
     sources = set()
     for name, mod in sys.modules.items():
-        if name in MODULE_BLACKLIST:
-            continue
         if mod is None:
             continue
         if not getattr(mod, "__file__", False):

--- a/seml/queue_experiments.py
+++ b/seml/queue_experiments.py
@@ -6,6 +6,7 @@ import pymongo
 import importlib
 import sys
 from pathlib import Path
+import logging
 
 from seml.database_utils import make_hash, upload_source_file
 from seml import parameter_utils as utils
@@ -368,7 +369,7 @@ def queue_experiments(config_file, force_duplicates, no_hash=False, no_config_ch
         batch_id = batch_id + 1
 
     if "project_root_dir" not in seml_config:
-        print("Warning: 'project_root_dir' not defined in seml config. Source files will not be uploaded.")
+        logging.warning("Warning: 'project_root_dir' not defined in seml config. Source files will not be uploaded.")
         uploaded_files = None
     else:
         uploaded_files = upload_sources(seml_config, collection, batch_id)
@@ -393,7 +394,7 @@ def queue_experiments(config_file, force_duplicates, no_hash=False, no_config_ch
 
 
 def upload_sources(seml_config, collection, batch_id):
-    root_dir = os.path.abspath(seml_config['project_root_dir'])
+    root_dir = os.path.abspath(os.path.expanduser(seml_config['project_root_dir']))
     sources = get_imported_files(seml_config['executable'], root_dir=root_dir)
     executable_abs = os.path.abspath(seml_config['executable'])
     executable_rel = Path(executable_abs).relative_to(root_dir)

--- a/seml/start_experiments.py
+++ b/seml/start_experiments.py
@@ -349,6 +349,7 @@ def do_work(collection_name, log_verbose, slurm=True, unobserved=False,
                     # clean up temp directory
                     shutil.rmtree(temp_dir)
 
+
 def print_commands(db_collection_name, log_verbose, unobserved, post_mortem, num_exps, filter_dict):
     configs = do_work(db_collection_name, log_verbose=True, slurm=False,
                       unobserved=True, post_mortem=False,

--- a/seml/start_experiments.py
+++ b/seml/start_experiments.py
@@ -100,7 +100,7 @@ def start_slurm_job(collection, exp_array, log_verbose, unobserved=False, post_m
     script += 'IFS=";" read -r -a exp_ids <<< "$exp_ids_str"\n'
 
     collection_str = exp_array[0][0]['seml']['db_collection']
-    if 'source_files' in exp_array[0][0]:
+    if 'source_files' in exp_array[0][0]['seml']:
         # we have uploaded the source files to the MongoDB
         with_sources = True
         script += "rdm=$RANDOM\n"  # random number for temp dir

--- a/seml/start_experiments.py
+++ b/seml/start_experiments.py
@@ -108,10 +108,10 @@ def start_slurm_job(collection, exp_array, log_verbose, unobserved=False, post_m
         script += 'while [ -d $tmpdir -a $ctr -le 100 ]; do tmpdir="/tmp/$RANDOM"; ctr=$ctr+1; done\n'
         script += 'if [ $ctr -ge 100 ]; then echo "could not create a temp dir"; exit 99; fi\n'
         script += "mkdir $tmpdir\n"
-        temp_prefix = 'PYTHONPATH=$tmpdir:$PYTHONPATH/'
+        # prepend the temp dir to $PYTHONPATH so it will be used by python.
+        script += 'export PYTHONPATH="$tmpdir:$PYTHONPATH"\n'
     else:
         with_sources = False
-        temp_prefix = ""
 
 
     script += "for exp_id in \"${exp_ids[@]}\"\n"
@@ -122,7 +122,6 @@ def start_slurm_job(collection, exp_array, log_verbose, unobserved=False, post_m
                f"--experiment_id ${{exp_id}} --database_collection {collection_str} {sources_argument}"
                f"--log-verbose {log_verbose} --unobserved {unobserved} --post-mortem {post_mortem})\n")
     script += "ret=$?\n"
-    script += f'cmd="{temp_prefix} $cmd"\n'  # prepend the temp directory if we have one
     script += "if [ $ret -eq 0 ]\n"
     script += "then\n"
     script += "    eval $cmd &\n"


### PR DESCRIPTION
<!-- 
Thank you for contributing a pull request!
Please name and describe your PR as you would write a
commit message.
-->

### What does this implement/fix?
<!--Please explain your changes.-->
Uploads an experiment's source files to the MongoDB upon queueing. We check which files from the project are imported by the experiment and upload these. When running an experiment, we download the stored sources to a temp directory and run the files from there. 

This prevents that a queued experiment might use source files that are different from when the experiment was queued.  

### Additional information
<!--Any additional information you think is important.-->
* We need to know the base path of the project in order to know which imported modules belong to the experiment's project. Therefore in the `seml` dict we now store the `project_root_dir`.
* References to the source files are stored under `seml.source_files` in an experiment's database entry.