### PR TITLE
Add `seml configure` command to get the MongoDB credentials of the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,8 @@ To get started, install **`SEML`** using the following commands:
 git clone https://github.com/TUM-KDD/seml.git
 cd seml
 python setup.py develop
-mkdir ~/.config/seml
-cp mongodb.config.example ~/.config/seml/mongodb.config
-# modify mongodb config to reflect your setup:
-vim ~/.config/seml/mongodb.config
+# provide your MongoDB credentials
+seml --configure
 ```
 ## Example
 See our simple [example](examples) to get familiar with how **`SEML`** works.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git clone https://github.com/TUM-KDD/seml.git
 cd seml
 python setup.py develop
 # provide your MongoDB credentials
-seml --configure
+seml configure
 ```
 ## Example
 See our simple [example](examples) to get familiar with how **`SEML`** works.

--- a/mongodb.config.example
+++ b/mongodb.config.example
@@ -1,5 +1,0 @@
-username: <your_username>
-password: <your_password>
-port: <port>
-database: <database_name>
-host: <host>

--- a/seml/config.py
+++ b/seml/config.py
@@ -208,11 +208,11 @@ def check_config(executable, conda_env, configs):
 
     for config in configs:
         config_added = {k: v for k, v in config.items() if k not in empty_run.config.keys()}
-        config_flattened = {k for k, v in sacred.utils.iterate_flattened(config_added)}
+        config_flattened = {k for k, _ in sacred.utils.iterate_flattened(config_added)}
 
         for conf in sorted(config_flattened):
             if not (set(sacred.utils.iter_prefixes(conf)) & captured_args):
-                raise sacred.utils.ConfigAddedError(conf, config=config_flattened)
+                raise sacred.utils.ConfigAddedError(conf, config=config_added)
 
         options = empty_run.config.copy()
         options.update(config)

--- a/seml/config.py
+++ b/seml/config.py
@@ -1,3 +1,5 @@
+import sys
+import logging
 import numpy as np
 import yaml
 import ast
@@ -22,7 +24,8 @@ def unpack_config(config):
             # value = munch.munchify(value)
             if key == 'random':
                 if 'samples' not in value:
-                    raise ValueError('Random parameters must specify "samples", i.e. the number of random samples.')
+                    logging.error('Random parameters must specify "samples", i.e. the number of random samples.')
+                    sys.exit(1)
                 keys = [k for k in value.keys() if k not in ['seed', 'samples']]
                 if 'seed' in value:
                     seed = value['seed']
@@ -192,10 +195,12 @@ def check_config(executable, conda_env, configs):
     # Extract experiment from module
     exps = [v for k, v in exp_module.__dict__.items() if type(v) == sacred.Experiment]
     if len(exps) == 0:
-        raise ValueError(f"Found no Sacred experiment. Something is wrong in '{executable}'.")
+        logging.error(f"Found no Sacred experiment. Something is wrong in '{executable}'.")
+        sys.exit(1)
     elif len(exps) > 1:
-        raise ValueError("Found more than 1 Sacred experiment. Can't check parameter configs. "
-                         "Disable via --no-config-check.")
+        logging.error("Found more than 1 Sacred experiment in '{executable}'. "
+                      "Can't check parameter configs. Disable via --no-config-check.")
+        sys.exit(1)
     exp = exps[0]
 
     empty_run = sacred.initialize.create_run(exp, exp.default_command, config_updates=None, named_configs=())
@@ -257,13 +262,16 @@ def read_config(config_path):
         config_dict = convert_values(yaml.load(conf, Loader=yaml.FullLoader))
 
     if "seml" not in config_dict:
-        raise ValueError("Please specify a 'seml' dictionary in the experiment configuration.")
+        logging.error("Please specify a 'seml' dictionary in the experiment configuration.")
+        sys.exit(1)
     seml_dict = config_dict['seml']
     del config_dict['seml']
     if "executable" not in seml_dict:
-        raise ValueError("Please specify an executable path for the experiment.")
+        logging.error("Please specify an executable path for the experiment.")
+        sys.exit(1)
     if "db_collection" not in seml_dict:
-        raise ValueError("Please specify a database collection to store the experimental results.")
+        logging.error("Please specify a database collection to store the experimental results.")
+        sys.exit(1)
 
     if 'slurm' in config_dict:
         slurm_dict = config_dict['slurm']

--- a/seml/database.py
+++ b/seml/database.py
@@ -63,10 +63,8 @@ def get_mongodb_config(path=SETTINGS.DATABASE.MONGODB_CONFIG_PATH):
     """
 
     access_dict = {}
-
-    error_str = f"Please supply your MongoDB credentials at {path} in the format:\n"\
-                "username: <your_username>\npassword: <your_password>\nport: <port>\n"\
-                "database:<database_name>\n host: <hostname>"
+    error_str = f"MongoDB credentials could not be read at {path}.\n"\
+                 "Please run seml --configure and provide your credentials."
 
     if not os.path.exists(path):
         raise ValueError(error_str)

--- a/seml/database.py
+++ b/seml/database.py
@@ -64,7 +64,7 @@ def get_mongodb_config(path=SETTINGS.DATABASE.MONGODB_CONFIG_PATH):
     """
 
     access_dict = {}
-    config_str = "\nPlease run seml --configure to provide your credentials."
+    config_str = "\nPlease run `seml configure` to provide your credentials."
 
     if not os.path.exists(path):
         logging.error(f"MongoDB credentials could not be read at '{path}'.{config_str}")

--- a/seml/database.py
+++ b/seml/database.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import gridfs
 import pymongo
@@ -63,11 +64,11 @@ def get_mongodb_config(path=SETTINGS.DATABASE.MONGODB_CONFIG_PATH):
     """
 
     access_dict = {}
-    error_str = f"MongoDB credentials could not be read at {path}.\n"\
-                 "Please run seml --configure and provide your credentials."
+    config_str = "\nPlease run seml --configure to provide your credentials."
 
     if not os.path.exists(path):
-        raise ValueError(error_str)
+        logging.error(f"MongoDB credentials could not be read at '{path}'.{config_str}")
+        sys.exit(1)
 
     with open(path, 'r') as f:
         for line in f.readlines():
@@ -78,11 +79,11 @@ def get_mongodb_config(path=SETTINGS.DATABASE.MONGODB_CONFIG_PATH):
                 value = split[1].strip()
                 access_dict[key] = value
 
-    assert 'username' in access_dict, f'No username found in {path}. {error_str}'
-    assert 'password' in access_dict, f'No password found in {path}. {error_str}'
-    assert 'port' in access_dict, f'No database port found in {path}. {error_str}'
-    assert 'host' in access_dict, f'No host found in {path}. {error_str}'
-    assert 'database' in access_dict, f'No database name found in {path}. {error_str}'
+    required_entries = ['username', 'password', 'port', 'host', 'database']
+    for entry in required_entries:
+        if entry not in access_dict:
+            logging.error(f"No {entry} found in '{path}'.{config_str}")
+            sys.exit(1)
 
     db_port = access_dict['port']
     db_name = access_dict['database']

--- a/seml/main.py
+++ b/seml/main.py
@@ -186,7 +186,7 @@ def main():
     else:  # otherwise remove the flag as it is not used elsewhere.
         if args.config_file is None:
             logging.error("Please provide a path to the config file.")
-            return
+            sys.exit(1)
 
     f = args.func
     del args.func

--- a/seml/main.py
+++ b/seml/main.py
@@ -3,8 +3,8 @@ import argparse
 import json
 import logging
 
-from seml.manage import report_status, cancel_experiments, delete_experiments, detect_killed, reset_experiments, \
-    mongodb_credentials_prompt
+from seml.manage import (report_status, cancel_experiments, delete_experiments, detect_killed, reset_experiments,
+                         mongodb_credentials_prompt)
 from seml.queue import queue_experiments
 from seml.start import start_experiments
 from seml.database import clean_unreferenced_artifacts

--- a/seml/manage.py
+++ b/seml/manage.py
@@ -193,7 +193,8 @@ def delete_experiments(config_file, sacred_id, filter_states, batch_id, filter_d
     else:
         exp = collection.find_one({'_id': sacred_id})
         if exp is None:
-            raise LookupError(f"No experiment found with ID {sacred_id}.")
+            logging.error(f"No experiment found with ID {sacred_id}.")
+            sys.exit(1)
         else:
             logging.info(f"Deleting experiment with ID {sacred_id}.")
             batch_ids_in_del = set([exp['batch_id']])
@@ -253,7 +254,8 @@ def reset_experiments(config_file, sacred_id, filter_states, batch_id, filter_di
     else:
         exp = collection.find_one({'_id': sacred_id})
         if exp is None:
-            raise LookupError(f"No experiment found with ID {sacred_id}.")
+            logging.error(f"No experiment found with ID {sacred_id}.")
+            sys.exit(1)
         else:
             logging.info(f"Resetting the state of experiment with ID {sacred_id}.")
             reset_single_experiment(collection, exp)

--- a/seml/manage.py
+++ b/seml/manage.py
@@ -362,7 +362,7 @@ def get_nonempty_input(field_name, num_trials=3):
 
 
 def mongodb_credentials_prompt():
-    logging.info('Configuring SEML. Warning: password will be stored in plain text.')
+    logging.info('Configuring SEML. Warning: Password will be stored in plain text.')
     host = get_nonempty_input("MongoDB host")
     port = input('Port (default: 27017):')
     port = "27017" if port == "" else port

--- a/seml/manage.py
+++ b/seml/manage.py
@@ -196,7 +196,7 @@ def delete_experiments(config_file, sacred_id, filter_states, batch_id, filter_d
             raise LookupError(f"No experiment found with ID {sacred_id}.")
         else:
             logging.info(f"Deleting experiment with ID {sacred_id}.")
-            batch_ids_in_del = set(exp['batch_id'])
+            batch_ids_in_del = set([exp['batch_id']])
             collection.delete_one({'_id': sacred_id})
 
     if len(batch_ids_in_del) > 0:

--- a/seml/manage.py
+++ b/seml/manage.py
@@ -369,10 +369,10 @@ def mongodb_credentials_prompt():
     password = get_nonempty_input("password")
     file_path = SETTINGS.DATABASE.MONGODB_CONFIG_PATH
     config_string = (f'username: {username}\n'
-                 f'password: {password}\n'
-                 f'port: {port}\n'
-                 f'database: {database}\n'
-                 f'host: {host}')
+                     f'password: {password}\n'
+                     f'port: {port}\n'
+                     f'database: {database}\n'
+                     f'host: {host}')
     logging.info(f"Saving the following configuration to {file_path}:\n"
                  f"{config_string.replace(f'password: {password}', 'password: ********')}"
                  )

--- a/seml/manage.py
+++ b/seml/manage.py
@@ -368,11 +368,11 @@ def mongodb_credentials_prompt():
     username = get_nonempty_input("user name")
     password = get_nonempty_input("password")
     file_path = SETTINGS.DATABASE.MONGODB_CONFIG_PATH
-    config_string = f'username: {username}\n'\
-                 f'password: {password}\n'\
-                 f'port: {port}\n'\
-                 f'database: {database}\n'\
-                 f'host: {host}'
+    config_string = (f'username: {username}\n'
+                 f'password: {password}\n'
+                 f'port: {port}\n'
+                 f'database: {database}\n'
+                 f'host: {host}')
     logging.info(f"Saving the following configuration to {file_path}:\n"
                  f"{config_string.replace(f'password: {password}', 'password: ********')}"
                  )

--- a/seml/manage.py
+++ b/seml/manage.py
@@ -1,10 +1,12 @@
 import logging
 import subprocess
 import datetime
+from getpass import getpass
 
 from seml.database import get_collection_from_config, build_filter_dict
 from seml.sources import delete_orphaned_sources
 from seml.utils import s_if, chunker
+from seml.settings import SETTINGS
 
 
 def report_status(config_file):
@@ -340,3 +342,41 @@ def get_slurm_arrays_tasks():
             return {}
     except subprocess.CalledProcessError:
         return {}
+
+
+def get_nonempty_input(field_name, num_trials=3):
+    get_input = getpass if "password" in field_name else input
+    field = get_input(f"Please input the {field_name}: ")
+    trials = 0
+    while (field is None or len(field) == 0) and trials < num_trials:
+        logging.error(f'{field_name} was empty.')
+        field = get_input(f"Please input the {field_name}")
+        trials += 1
+    if field is None or len(field) == 0:
+        raise ValueError(f"Did not receive an input for {num_trials}. Aborting.")
+    return field
+
+
+def mongodb_credentials_prompt():
+    logging.info('Configuring SEML. Warning: password will be stored in plain text.')
+    host = get_nonempty_input("MongoDB host")
+    port = input('Port (default: 27017):')
+    if port == "":
+        port = "27017"
+    database = get_nonempty_input("database name")
+    username = get_nonempty_input("user name")
+    password = get_nonempty_input("password")
+    file_path = SETTINGS.DATABASE.MONGODB_CONFIG_PATH
+    logging.info(f"Saving the following configuration to {file_path}:\n"
+                 f'username: {username}\n'
+                 'password: ********\n'
+                 f'port: {port}\n'
+                 f'database: {database}\n'
+                 f'host: {host}')
+
+    with open(file_path, 'w') as f:
+        f.write(f'username: {username}\n')
+        f.write(f'password: {password}\n')
+        f.write(f'port: {port}\n')
+        f.write(f'database: {database}\n')
+        f.write(f'host: {host}\n')

--- a/seml/parameters.py
+++ b/seml/parameters.py
@@ -1,3 +1,5 @@
+import sys
+import logging
 import itertools
 import numpy as np
 
@@ -67,7 +69,8 @@ def sample_parameter(parameter, samples, seed=None, parent_key=''):
     """
 
     if "type" not in parameter:
-        raise ValueError("No type found in parameter {}".format(parameter))
+        logging.error("No type found in parameter {}".format(parameter))
+        sys.exit(1)
     return_items = []
 
     if seed is not None:
@@ -90,7 +93,8 @@ def sample_parameter(parameter, samples, seed=None, parent_key=''):
 
     elif param_type == "loguniform":
         if parameter['min'] <= 0:
-            raise ValueError("Cannot take log of values <= 0")
+            logging.error("Cannot take log of values <= 0")
+            sys.exit(1)
         min_val = np.log(parameter['min'])
         max_val = np.log(parameter['max'])
         sampled_values = np.exp(np.random.uniform(min_val, max_val, samples))
@@ -145,7 +149,8 @@ def generate_grid(parameter, parent_key=''):
 
     """
     if "type" not in parameter:
-        raise ValueError("No type found in parameter {}".format(parameter))
+        logging.error("No type found in parameter {}".format(parameter))
+        sys.exit(1)
 
     param_type = parameter['type']
 

--- a/seml/prepare_experiment.py
+++ b/seml/prepare_experiment.py
@@ -27,8 +27,8 @@ if __name__ == "__main__":
     exp = collection.find_one({'_id': exp_id})
     use_stored_sources = args.stored_sources_dir is not None
     if use_stored_sources and not os.listdir(args.stored_sources_dir):
-        assert ("source_files" in exp['seml'],
-                "--stored-sources-dir was supplied but queued experiment does not contain stored source files.")
+        assert "source_files" in exp['seml'],\
+               "--stored-sources-dir was supplied but queued experiment does not contain stored source files."
         load_sources_from_db(exp, to_directory=args.stored_sources_dir)
 
     exe, config = get_command_from_exp(exp, verbose=args.verbose,

--- a/seml/prepare_experiment.py
+++ b/seml/prepare_experiment.py
@@ -27,8 +27,8 @@ if __name__ == "__main__":
     exp = collection.find_one({'_id': exp_id})
     use_stored_sources = args.stored_sources_dir is not None
     if use_stored_sources and not os.listdir(args.stored_sources_dir):
-        assert "source_files" in exp['seml'], \
-            "--stored-sources-dir was supplied but queued experiment does not contain stored source files."
+        assert ("source_files" in exp['seml'],
+                "--stored-sources-dir was supplied but queued experiment does not contain stored source files.")
         load_sources_from_db(exp, to_directory=args.stored_sources_dir)
 
     exe, config = get_command_from_exp(exp, verbose=args.verbose,

--- a/seml/settings.py
+++ b/seml/settings.py
@@ -1,5 +1,6 @@
 from munch import munchify
 import os
+from pathlib import Path
 import seml
 __all__ = ("SETTINGS",)
 seml_base = os.path.dirname(os.path.abspath(seml.__file__))
@@ -7,8 +8,8 @@ seml_base = os.path.dirname(os.path.abspath(seml.__file__))
 SETTINGS = munchify(
     {
         "DATABASE": {
-            # location of the MongoDB config. Default: /path/to/seml/monogdb.config
-            "MONGODB_CONFIG_PATH": f'{seml_base}/mongodb.config'
+            # location of the MongoDB config. Default: $HOME/.config/seml/monogdb.config
+            "MONGODB_CONFIG_PATH": f'{str(Path.home())}/.config/seml/mongodb.config'
         },
         "SLURM_DEFAULT": {
             'experiments_per_job': 1,

--- a/seml/settings.py
+++ b/seml/settings.py
@@ -1,14 +1,14 @@
 from munch import munchify
-from pathlib import Path
-
+import os
+import seml
 __all__ = ("SETTINGS",)
-
+seml_base = os.path.dirname(os.path.abspath(seml.__file__))
 
 SETTINGS = munchify(
     {
         "DATABASE": {
-            # location of the MongoDB config. Default: $HOME/.config/seml/monogdb.config
-            "MONGODB_CONFIG_PATH": f'{str(Path.home())}/.config/seml/mongodb.config'
+            # location of the MongoDB config. Default: /path/to/seml/monogdb.config
+            "MONGODB_CONFIG_PATH": f'{seml_base}/mongodb.config'
         },
         "SLURM_DEFAULT": {
             'experiments_per_job': 1,

--- a/seml/sources.py
+++ b/seml/sources.py
@@ -143,7 +143,7 @@ def load_sources_from_db(exp, to_directory):
         with open(f'{to_directory}/{path}', 'wb') as f:
             file = fs.find_one(_id)
             if file is None:
-                raise ValueError(f"Source file was not found on the MongoDB.")
+                raise ValueError(f"Source file with ID '{_id}' was not found in the MongoDB.")
             f.write(file.read())
 
 


### PR DESCRIPTION

<!-- 
Thank you for contributing a pull request!
Please name and describe your PR as you would write a
commit message.
-->

### What does this implement/fix?
<!--Please explain your changes.-->
Adds the command `seml --configure`, which prompts the user to provide their MongoDB credentials. Therefore the users no longer have to manually create directories / files. The new location of the config file is in the `seml` base directory in the package.

### Additional information
<!--Any additional information you think is important.-->
The `config_file` argument in the main file is now optional (`nargs='?'`). This was necessary in order to be able to run `seml --configure` without an input config file.
