### PR TITLE
Treat paths as relative to either project root dir or the config_dir.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -133,10 +133,10 @@ There are two special blocks for meta-configuration: `seml` and `slurm`.
 The `seml` block is required for every experiment. It has to contain the following values:
    - `executable`: Name of the Python script containing the experiment
 Optionally, it can contain
+   - `name`: Prefix for output file and Slurm job name. Default: Collection name
+   - `output_dir`: Directory to store log files in. Default: Current directory
    - `conda_environment`: Specifies which Anaconda virtual environment will be activated before the experiment is executed. 
                           Default: The environment used when queuing.
-   - `name`: Name of output file and job name used by Slurm. Default: Collection name
-   - `output_dir`: Directory to store log files in. Default: Current directory
    - `project_root_dir`: (Relative or absolute) path to the root of the project. seml will then upload all the source
                          files imported by the experiment to the MongoDB. Moreover, the uploaded source files will be
                          downloaded before starting an experiment, so any changes to the source files in the project

--- a/examples/README.md
+++ b/examples/README.md
@@ -131,7 +131,8 @@ There are two special blocks for meta-configuration: `seml` and `slurm`.
 
 ### `seml` block
 The `seml` block is required for every experiment. It has to contain the following values:
-   - `executable`: Name of the Python script containing the experiment
+   - `executable`: Name of the Python script containing the experiment. The path should preferably be given relative
+                   to the `project_root_dir`. Alternatively, you can define it relative to the config file.
 Optionally, it can contain
    - `name`: Prefix for output file and Slurm job name. Default: Collection name
    - `output_dir`: Directory to store log files in. Default: Current directory

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -2,7 +2,8 @@
 #
 # There are two special blocks. The 'seml' block is required for every experiment.
 # It has to contain the following values:
-# executable:    Name of the Python script containing the experiment
+# executable:        Name of the Python script containing the experiment. The path should preferably be given relative
+#                    to the `project_root_dir`. Alternatively, you can define it relative to the config file.
 # It can optionally also contain the following values:
 # name:              Prefix for output file and Slurm job name. Default: Collection name
 # output_dir:        Directory to store log files in. Default: Current directory

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -4,10 +4,10 @@
 # It has to contain the following values:
 # executable:    Name of the Python script containing the experiment
 # It can optionally also contain the following values:
+# name:              Prefix for output file and Slurm job name. Default: Collection name
+# output_dir:        Directory to store log files in. Default: Current directory
 # conda_environment: Specifies which Anaconda virtual environment will be activated before the experiment is executed.
 #                    Default: The environment used when queuing.
-# name:              Name of output file and job name used by Slurm. Default: Collection name
-# output_dir:        Directory to store log files in. Default: Current directory
 # project_root_dir:  (Relative or absolute) path to the root of the project. seml will then upload all the source
 #                    files imported by the experiment to the MongoDB. Moreover, the uploaded source files will be
 #                    downloaded before starting an experiment, so any changes to the source files in the project

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -49,7 +49,7 @@
 
 
 seml:
-  executable: example_experiment.py
+  executable: examples/example_experiment.py
   name: example_experiment
   output_dir: logs
   project_root_dir: ..

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -49,6 +49,10 @@
 
 
 seml:
+  # Executable path should be relative to the project_root_dir.
+  # For reasons of backward compatibility SEML also supports relative paths to the location of the config file.
+  # In case there is a file present both relative to the project root and the config file,
+  # the former one has precedence.
   executable: examples/example_experiment.py
   name: example_experiment
   output_dir: logs

--- a/seml/config.py
+++ b/seml/config.py
@@ -5,6 +5,7 @@ import yaml
 import ast
 import jsonpickle
 import json
+import os
 
 from seml.sources import import_exe
 from seml.parameters import sample_random_configs, generate_grid, cartesian_product_dict
@@ -268,6 +269,14 @@ def read_config(config_path):
         logging.error("Please specify a 'seml' dictionary in the experiment configuration.")
         sys.exit(1)
     seml_dict = config_dict['seml']
+    config_dir = os.path.abspath(os.path.dirname(config_path))
+    seml_dict['config_dir'] = config_dir
+    os.chdir(config_dir)
+
+    if 'project_root_dir' in seml_dict:
+        seml_dict['project_root_dir'] = os.path.abspath(os.path.realpath(seml_dict['project_root_dir']))
+        os.chdir(seml_dict['project_root_dir'])  # use project root as base dir from now on
+
     del config_dict['seml']
     if "executable" not in seml_dict:
         logging.error("Please specify an executable path for the experiment.")

--- a/seml/config.py
+++ b/seml/config.py
@@ -201,7 +201,7 @@ def check_config(executable, conda_env, configs):
         sys.exit(1)
     elif len(exps) > 1:
         logging.error(f"Found more than 1 Sacred experiment in '{executable}'. "
-                      "Can't check parameter configs. Disable via --no-config-check.")
+                      f"Can't check parameter configs. Disable via --no-config-check.")
         sys.exit(1)
     exp = exps[0]
 
@@ -273,8 +273,11 @@ def read_config(config_path):
     seml_dict = config_dict['seml']
     del config_dict['seml']
 
-    determine_working_dir_and_chdir(config_path, seml_dict)
+    set_executable_and_working_dir(config_path, seml_dict)
 
+    if "db_collection" in seml_dict:
+        logging.warning("Specifying a the database collection in the config has been deprecated. "
+                        "Please provide it via the command line instead.")
     if 'output_dir' in seml_dict:
         seml_dict['output_dir'] = os.path.abspath(os.path.realpath(seml_dict['output_dir']))
 
@@ -286,7 +289,7 @@ def read_config(config_path):
         return seml_dict, None, config_dict
 
 
-def determine_working_dir_and_chdir(config_path, seml_dict):
+def set_executable_and_working_dir(config_path, seml_dict):
     """
     Determine the working directory of the project and chdir into the working directory.
     Parameters
@@ -306,9 +309,6 @@ def determine_working_dir_and_chdir(config_path, seml_dict):
         logging.error("Please specify an executable path for the experiment.")
         sys.exit(1)
     executable = seml_dict['executable']
-    if "db_collection" in seml_dict:
-        logging.warning("Specifying a the database collection in the config has been deprecated. "
-                        "Please provide it via the command line instead.")
     executable_relative_to_config = os.path.exists(executable)
     executable_relative_to_project_root = False
     if 'project_root_dir' in seml_dict:

--- a/seml/config.py
+++ b/seml/config.py
@@ -312,12 +312,12 @@ def determine_working_dir_and_chdir(config_dir, seml_dict):
     executable_relative_to_project_root = False
     if 'project_root_dir' in seml_dict:
         working_dir = os.path.abspath(os.path.realpath(seml_dict['project_root_dir']))
-        seml_dict['has_root_dir'] = True
+        seml_dict['use_uploaded_sources'] = True
         os.chdir(working_dir)  # use project root as base dir from now on
         executable_relative_to_project_root = os.path.exists(executable)
         del seml_dict['project_root_dir']  # from now on we use only the working dir
     else:
-        seml_dict['has_root_dir'] = False
+        seml_dict['use_uploaded_sources'] = False
         logging.warning("'project_root_dir' not defined in seml config. Source files will not be uploaded.")
     seml_dict['working_dir'] = working_dir
     if not (executable_relative_to_config or executable_relative_to_project_root):

--- a/seml/config.py
+++ b/seml/config.py
@@ -277,6 +277,9 @@ def read_config(config_path):
         seml_dict['project_root_dir'] = os.path.abspath(os.path.realpath(seml_dict['project_root_dir']))
         os.chdir(seml_dict['project_root_dir'])  # use project root as base dir from now on
 
+    if 'output_dir' in seml_dict:
+        seml_dict['output_dir'] = os.path.abspath(os.path.realpath(seml_dict['output_dir']))
+
     del config_dict['seml']
     if "executable" not in seml_dict:
         logging.error("Please specify an executable path for the experiment.")

--- a/seml/config.py
+++ b/seml/config.py
@@ -271,9 +271,9 @@ def read_config(config_path):
         sys.exit(1)
 
     seml_dict = config_dict['seml']
-    config_dir = os.path.abspath(os.path.dirname(config_path))
-    determine_working_dir_and_chdir(config_dir, seml_dict)
     del config_dict['seml']
+
+    determine_working_dir_and_chdir(config_path, seml_dict)
 
     if 'output_dir' in seml_dict:
         seml_dict['output_dir'] = os.path.abspath(os.path.realpath(seml_dict['output_dir']))
@@ -286,18 +286,19 @@ def read_config(config_path):
         return seml_dict, None, config_dict
 
 
-def determine_working_dir_and_chdir(config_dir, seml_dict):
+def determine_working_dir_and_chdir(config_path, seml_dict):
     """
     Determine the working directory of the project and chdir into the working directory.
     Parameters
     ----------
-    config_dir: path to the config file
-    seml_dict: seml config dir
+    config_path: Path to the config file
+    seml_dict: SEML config dictionary
 
     Returns
     -------
     None
     """
+    config_dir = os.path.abspath(os.path.dirname(config_path))
 
     working_dir = config_dir
     os.chdir(working_dir)

--- a/seml/manage.py
+++ b/seml/manage.py
@@ -214,7 +214,7 @@ def reset_single_experiment(collection, exp):
     keep_entries = ['batch_id', 'status', 'seml', 'slurm', 'config', 'config_hash', 'queue_time', 'git']
 
     # Clean up SEML dictionary
-    keep_seml = {'executable', 'conda_environment', 'output_dir', 'source_files', 'working_dir'}
+    keep_seml = {'executable', 'executable_relative', 'conda_environment', 'output_dir', 'source_files', 'working_dir'}
     seml_keys = set(exp['seml'].keys())
     for key in seml_keys - keep_seml:
         del exp['seml'][key]

--- a/seml/manage.py
+++ b/seml/manage.py
@@ -215,7 +215,7 @@ def reset_single_experiment(collection, exp):
 
     # Clean up SEML dictionary
     keep_seml = {'executable', 'conda_environment', 'output_dir', 'source_files',
-                 'project_root_dir', 'executable_relative'}
+                 'project_root_dir', 'config_dir'}
     seml_keys = set(exp['seml'].keys())
     for key in seml_keys - keep_seml:
         del exp['seml'][key]

--- a/seml/manage.py
+++ b/seml/manage.py
@@ -214,8 +214,7 @@ def reset_single_experiment(collection, exp):
     keep_entries = ['batch_id', 'status', 'seml', 'slurm', 'config', 'config_hash', 'queue_time', 'git']
 
     # Clean up SEML dictionary
-    keep_seml = {'executable', 'conda_environment', 'output_dir', 'source_files',
-                 'project_root_dir', 'config_dir'}
+    keep_seml = {'executable', 'conda_environment', 'output_dir', 'source_files', 'working_dir'}
     seml_keys = set(exp['seml'].keys())
     for key in seml_keys - keep_seml:
         del exp['seml'][key]

--- a/seml/prepare_experiment.py
+++ b/seml/prepare_experiment.py
@@ -36,8 +36,7 @@ if __name__ == "__main__":
         load_sources_from_db(exp, collection, to_directory=args.stored_sources_dir)
 
     exe, config = get_command_from_exp(exp, db_collection_name, verbose=args.verbose,
-                                       unobserved=args.unobserved, post_mortem=args.post_mortem,
-                                       relative=use_stored_sources)
+                                       unobserved=args.unobserved, post_mortem=args.post_mortem)
 
     cmd = f"python {exe} with {' '.join(config)}"
     if use_stored_sources:

--- a/seml/queuing.py
+++ b/seml/queuing.py
@@ -138,7 +138,7 @@ def queue_experiments(db_collection_name, config_file, force_duplicates, no_hash
     else:
         batch_id = batch_id + 1
 
-    if seml_config['has_root_dir']:
+    if seml_config['use_uploaded_sources']:
         uploaded_files = upload_sources(seml_config, collection, batch_id)
     else:
         uploaded_files = None

--- a/seml/queuing.py
+++ b/seml/queuing.py
@@ -138,11 +138,10 @@ def queue_experiments(db_collection_name, config_file, force_duplicates, no_hash
     else:
         batch_id = batch_id + 1
 
-    if "project_root_dir" not in seml_config:
-        logging.warning("'project_root_dir' not defined in seml config. Source files will not be uploaded.")
-        uploaded_files = None
-    else:
+    if seml_config['has_root_dir']:
         uploaded_files = upload_sources(seml_config, collection, batch_id)
+    else:
+        uploaded_files = None
 
     if not no_config_check:
         check_config(seml_config['executable'], seml_config['conda_environment'], configs)

--- a/seml/slurm_template.sh
+++ b/seml/slurm_template.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 {sbatch_options}
 
-# Move to directory from which the experiments were started
-cd ${{SLURM_SUBMIT_DIR}}
+# Move either to project root dir or the config file path.
+cd {project_root_dir}
 
 # Print job information
 echo "Starting job ${{SLURM_JOBID}}"

--- a/seml/slurm_template.sh
+++ b/seml/slurm_template.sh
@@ -2,7 +2,7 @@
 {sbatch_options}
 
 # Move either to project root dir or the config file path.
-cd {project_root_dir}
+cd {working_dir}
 
 # Print job information
 echo "Starting job ${{SLURM_JOBID}}"

--- a/seml/sources.py
+++ b/seml/sources.py
@@ -77,28 +77,14 @@ def get_imported_sources(executable, root_dir, conda_env):
 
 
 def upload_sources(seml_config, collection, batch_id):
-    root_dir = os.path.abspath(os.path.expanduser(seml_config['project_root_dir']))
-
-    if not os.path.exists(seml_config['executable']):
-        # try if the executable path is relative to the config file
-        os.chdir(seml_config['config_dir'])
-        if not os.path.exists(seml_config['executable']):
-            logging.error(f"Could not find the executable under {seml_config['project_root_dir']} or"
-                          f"{seml_config['config_dir']}.")
-            exit(1)
+    root_dir = os.path.abspath(os.path.expanduser(seml_config['working_dir']))
 
     sources = get_imported_sources(seml_config['executable'], root_dir=root_dir,
                                    conda_env=seml_config['conda_environment'])
     executable_abs = os.path.abspath(seml_config['executable'])
-    executable_rel = Path(executable_abs).relative_to(root_dir)
 
     if executable_abs not in sources:
         raise ValueError(f"Executable {executable_abs} was not found in the sources to upload.")
-    seml_config['executable'] = str(executable_rel)
-
-    if os.getcwd() != seml_config['project_root_dir']:
-        # set project root dir as base path again
-        os.chdir(seml_config['project_root_dir'])
 
     uploaded_files = []
     for s in sources:

--- a/seml/sources.py
+++ b/seml/sources.py
@@ -74,6 +74,15 @@ def get_imported_sources(executable, root_dir, conda_env):
 
 def upload_sources(seml_config, collection, batch_id):
     root_dir = os.path.abspath(os.path.expanduser(seml_config['project_root_dir']))
+
+    if not os.path.exists(seml_config['executable']):
+        # try if the executable path is relative to the config file
+        os.chdir(seml_config['config_dir'])
+        if not os.path.exists(seml_config['executable']):
+            logging.error(f"Could not find the executable under {seml_config['project_root_dir']} or"
+                          f"{seml_config['config_dir']}.")
+            exit(1)
+
     sources = get_imported_sources(seml_config['executable'], root_dir=root_dir,
                                    conda_env=seml_config['conda_environment'])
     executable_abs = os.path.abspath(seml_config['executable'])
@@ -81,7 +90,11 @@ def upload_sources(seml_config, collection, batch_id):
 
     if executable_abs not in sources:
         raise ValueError(f"Executable {executable_abs} was not found in the sources to upload.")
-    seml_config['executable_relative'] = str(executable_rel)
+    seml_config['executable'] = str(executable_rel)
+
+    if os.getcwd() != seml_config['project_root_dir']:
+        # set project root dir as base path again
+        os.chdir(seml_config['project_root_dir'])
 
     uploaded_files = []
     for s in sources:

--- a/seml/start.py
+++ b/seml/start.py
@@ -21,6 +21,8 @@ def get_command_from_exp(exp, db_collection_name, verbose=False, unobserved=Fals
     if 'executable' not in exp['seml']:
         raise ValueError(f"No executable found for experiment {exp['_id']}. Aborting.")
     exe = exp['seml']['executable']
+    if 'executable_relative' in exp['seml']:  # backwards compatibility
+        exe = exp['seml']['executable_relative']
 
     config = exp['config']
     config['db_collection'] = db_collection_name
@@ -134,8 +136,6 @@ def start_slurm_job(collection, exp_array, unobserved=False, post_mortem=False, 
     template = pkg_resources.resource_string(__name__, "slurm_template.sh").decode("utf-8")
     if 'working_dir' in exp_array[0][0]['seml']:
         working_dir = exp_array[0][0]['seml']['working_dir']
-    elif 'project_root_dir' in exp_array[0][0]['seml']:
-        working_dir = exp_array[0][0]['seml']['project_root_dir']
     else:
         working_dir = "${{SLURM_SUBMIT_DIR}}"
 

--- a/seml/start.py
+++ b/seml/start.py
@@ -132,8 +132,12 @@ def start_slurm_job(collection, exp_array, unobserved=False, post_mortem=False, 
 
     # Construct Slurm script
     template = pkg_resources.resource_string(__name__, "slurm_template.sh").decode("utf-8")
-    working_dir = (exp_array[0][0]['seml']['working_dir'] if 'working_dir' in exp_array[0][0]['seml']
-                   else exp_array[0][0]['project_root_dir'])  # backward compatibility
+    if 'working_dir' in exp_array[0][0]['seml']:
+        working_dir = exp_array[0][0]['seml']['working_dir']
+    elif 'project_root_dir' in exp_array[0][0]['seml']:
+        working_dir = exp_array[0][0]['seml']['project_root_dir']
+    else:
+        working_dir = "${{SLURM_SUBMIT_DIR}}"
 
     script = template.format(
             sbatch_options=sbatch_options_str,


### PR DESCRIPTION
<!-- 
Thank you for contributing a pull request!
Please name and describe your PR as you would write a
commit message.
-->

### What does this implement/fix?
<!--Please explain your changes.-->
Treat all paths as relative either to the `project_root_dir` (if provided) or else the `config_dir`. This way, it does not matter from which directory the `seml` commands are run.

### Additional information
`executable` in the YAML file should now be relative to the project root dir.
<!--Any additional information you think is important.-->
