### PR TITLE
Fix queuing for configuration file without slurm

### DIFF
--- a/seml/queuing.py
+++ b/seml/queuing.py
@@ -119,7 +119,8 @@ def queue_experiments(db_collection_name, config_file, force_duplicates, no_hash
             seml_config['conda_environment'] = None
 
     # Set Slurm config with default parameters as fall-back option
-
+    if slurm_config is None:
+        slurm_config = {'sbatch_options': {}}
     for k, v in SETTINGS.SLURM_DEFAULT['sbatch_options'].items():
         if k not in slurm_config['sbatch_options']:
             slurm_config['sbatch_options'][k] = v


### PR DESCRIPTION
### Reference issue
Closes #26


### What does this implement/fix?
When the `slurm` block is missing in the experiment configuration file, the default configuration from `SETTINGS.SLURM_DEFAULT` is taken. Copying the defaults was implemented before, but failed when `slurm_config` was `None` (which is the case when the `slurm` block is missing in the config file).

### Additional information
IMO it makes sense to have a config without the `slurm` block, when one wants to take the default config or when experiments are only run locally.
