### PR TITLE
add db_filter to get_results

### DIFF
--- a/seml/evaluation.py
+++ b/seml/evaluation.py
@@ -22,18 +22,18 @@ def parse_jsonpickle(db_entry):
 
 def get_results(db_collection_name, fields=['config', 'result'],
                 to_data_frame=False, mongodb_config=None, suffix=None,
-                states=['COMPLETED'], db_filter={}, parallel=False):
+                states=['COMPLETED'], filter_dict={}, parallel=False):
     import pandas as pd
 
     collection = get_collection(db_collection_name, mongodb_config=mongodb_config, suffix=suffix)
 
     if len(states) > 0:
-        if 'status' in db_filter:
-            logging.warning("'states' argument is not empty and will overwrite 'db_filter['status']'.")
-        db_filter['status'] = {'$in': states}
+        if 'status' in filter_dict:
+            logging.warning("'states' argument is not empty and will overwrite 'filter_dict['status']'.")
+        filter_dict['status'] = {'$in': states}
 
-    cursor = collection.find(db_filter, fields)
-    results = [x for x in tqdm(cursor, total=collection.count_documents(db_filter))]
+    cursor = collection.find(filter_dict, fields)
+    results = [x for x in tqdm(cursor, total=collection.count_documents(filter_dict))]
 
     if parallel:
         from multiprocessing import Pool

--- a/seml/evaluation.py
+++ b/seml/evaluation.py
@@ -21,16 +21,18 @@ def parse_jsonpickle(db_entry):
 
 def get_results(db_collection_name, fields=['config', 'result'],
                 to_data_frame=False, mongodb_config=None, suffix=None,
-                states=['COMPLETED'], parallel=False):
+                states=['COMPLETED'], db_filter=None, parallel=False):
     import pandas as pd
 
     collection = get_collection(db_collection_name, mongodb_config=mongodb_config, suffix=suffix)
-    if len(states) > 0:
-        filter = {'status': {'$in': states}}
-    else:
-        filter = {}
-    cursor = collection.find(filter, fields)
-    results = [x for x in tqdm(cursor, total=collection.count_documents(filter))]
+
+    if db_filter is None:
+        if len(states) > 0:
+            db_filter = {'status': {'$in': states}}
+        else:
+            db_filter = {}
+    cursor = collection.find(db_filter, fields)
+    results = [x for x in tqdm(cursor, total=collection.count_documents(db_filter))]
 
     if parallel:
         from multiprocessing import Pool

--- a/seml/evaluation.py
+++ b/seml/evaluation.py
@@ -1,3 +1,4 @@
+import logging
 import json
 import jsonpickle
 from tqdm.autonotebook import tqdm
@@ -21,16 +22,16 @@ def parse_jsonpickle(db_entry):
 
 def get_results(db_collection_name, fields=['config', 'result'],
                 to_data_frame=False, mongodb_config=None, suffix=None,
-                states=['COMPLETED'], db_filter=None, parallel=False):
+                states=['COMPLETED'], db_filter={}, parallel=False):
     import pandas as pd
 
     collection = get_collection(db_collection_name, mongodb_config=mongodb_config, suffix=suffix)
 
-    if db_filter is None:
-        if len(states) > 0:
-            db_filter = {'status': {'$in': states}}
-        else:
-            db_filter = {}
+    if len(states) > 0:
+        if 'status' in db_filter:
+            logging.warning("'states' argument is not empty and will overwrite 'db_filter['status']'.")
+        db_filter['status'] = {'$in': states}
+
     cursor = collection.find(db_filter, fields)
     results = [x for x in tqdm(cursor, total=collection.count_documents(db_filter))]
 


### PR DESCRIPTION
Add the option to specify a dictionary for more fine grained filtering of the results. If the filter dictionary is specified (by default it is not) ignore the `states` parameter.

Rename `filter` to `db_filter` since `filter` is a Python keyword.