### PR TITLE
Throw an error for parameter re-definitions across different blocks

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,11 @@ Before starting, please make sure you have your MongoDB credentials stored in `$
 
 ## Experiment configuration
 
-In `example_config.yaml` we define the parameter configurations that will be run.
+In `example_config.yaml` we define the parameter configurations that will be run. 
+For a more advanced example with modular structure using 
+[Sacred prefixes](https://sacred.readthedocs.io/en/stable/configuration.html#prefix), 
+see the [advanced example configuration](advanced_example_config.yaml) and the corresponding 
+[experiment](advanced_example_experiment.py).
 <details><summary><b>Example config file</b></summary>
   
 ```yaml
@@ -34,20 +38,12 @@ fixed:
   display_step: 25
 
 grid:
-  regularization_params:
-    type: parameter_collection
-    params:
-      dropout:
-        type: choice
-        options:
-          - 0.5
-          - 0.6
 
-      reg_scale:
-        type: choice
-        options:
-          - 1e-4
-          - 1e-5
+  regularization_params.reg_scale:
+    type: choice
+    options:
+      - 1e-4
+      - 1e-5
 
   learning_rate:
     type: loguniform
@@ -59,14 +55,11 @@ random:
   samples: 3
   seed: 821
 
-  regularization_params:
-    type: parameter_collection
-    params:
-      dropout:
-        type: uniform
-        min: 0.0
-        max: 0.7
-        seed: 222
+  regularization_params.dropout:
+    type: uniform
+    min: 0.0
+    max: 0.7
+    seed: 222
 
 small_datasets:
 
@@ -87,14 +80,11 @@ small_datasets:
     samples: 3
     seed: 2223
 
-    regularization_params:
-      type: parameter_collection
-      params:
-        dropout:
-          type: uniform
-          min: 0.0
-          max: 0.7
-          seed: 222
+    regularization_params.dropout:
+      type: uniform
+      min: 0.0
+      max: 0.7
+      seed: 222
 
 large_datasets:
 
@@ -152,20 +142,10 @@ If a specific configuration (e.g. `large_datasets`) defines the same parameters 
 `grid`), they will override the ones defined before, e.g. the learning rate in the example above.
 This means that for all configurations in the `large_datasets` the learning rate will be `0.001` and not `0.01` or 
 `0.05` as defined in the root of the document.
-
-If a parameter is defined in (at least) two **different blocks** in `[grid, random, fixed]`, `seml` will throw an error to avoid ambiguity.
-This applies across levels, e.g. we can have `param1` in the root `fixed` configuration, and again `param1` in the
- `grid` configuration of a sub-config (e.g. `small_datasets` in `example_config.yaml`), and `seml` will abort.
-
 This can be nested arbitrarily deeply (be aware of combinatorial explosion of the parameter space, though).
 
-### Conflicting parameters
-If a parameter is defined in at least two of `[grid, random, fixed]`, `seml` will throw an error to avoid ambiguity.
-This applies across levels, e.g. we can have `param1` in the root `fixed` configuration, and again `param1` in the
- `grid` configuration of a sub-config (e.g. `small_datasets` in `example_config.yaml`), and `seml` will abort.
- 
- Note that this does not apply to parameters in the same configuration type (i.e. `fixed`, `grid`, `random`). Here, the 
- deeper definition overrides all previous definitions of a parameter. 
+If a parameter is defined in (at least) two **different blocks** in `[grid, random, fixed]`, `seml` will throw an error to avoid ambiguity.
+If a parameter is re-defined in a sub-configuration, the redefinition overrides any previous definitions of that parameter.
 
 ### Grid parameters
 In an experiment config, under `grid` you can define parameters that should be sampled from a regular grid. Currently supported

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,16 +34,8 @@ slurm:
 
 fixed:
   max_epochs: 500
-  patience: 10
-  display_step: 25
 
 grid:
-
-  regularization_params.reg_scale:
-    type: choice
-    options:
-      - 1e-4
-      - 1e-5
 
   learning_rate:
     type: loguniform
@@ -55,6 +47,7 @@ random:
   samples: 3
   seed: 821
 
+  # SEML supports dot-notation for nested dictionaries.
   regularization_params.dropout:
     type: uniform
     min: 0.0
@@ -74,17 +67,16 @@ small_datasets:
       type: choice
       options:
         - [16]
-        - [32, 16]
+        - [32, 16]  # this will be parsed into a Python list.
 
   random:
     samples: 3
     seed: 2223
 
-    regularization_params.dropout:
-      type: uniform
-      min: 0.0
-      max: 0.7
-      seed: 222
+    max_epochs:
+       type: randint
+       min: 200
+       max: 1000
 
 large_datasets:
 
@@ -138,13 +130,13 @@ The special 'slurm' block contains the slurm parameters. This block and all valu
 In the `small_datasets` and `large_datasets` (names are of course only examples; you can name sub-configs as you like) we have specified different sets of parameters to try.
 They will be combined with the parameters in `grid` in the root of the document.
 
-If a specific configuration (e.g. `large_datasets`) defines the same parameters **in the same block** (`fixed`, `random`, 
-`grid`), they will override the ones defined before, e.g. the learning rate in the example above.
+If a specific configuration (e.g. `large_datasets`) defines the same parameters as a higher-level configuration (e.g., the "root" configuration),
+ they will override the ones defined before, e.g. the learning rate in the example above.
 This means that for all configurations in the `large_datasets` the learning rate will be `0.001` and not `0.01` or 
 `0.05` as defined in the root of the document.
 This can be nested arbitrarily deeply (be aware of combinatorial explosion of the parameter space, though).
 
-If a parameter is defined in (at least) two **different blocks** in `[grid, random, fixed]`, `seml` will throw an error to avoid ambiguity.
+If a parameter is defined in (at least) two **different blocks** in `[grid, random, fixed]` on the same level, `seml` will throw an error to avoid ambiguity.
 If a parameter is re-defined in a sub-configuration, the redefinition overrides any previous definitions of that parameter.
 
 ### Grid parameters

--- a/examples/advanced_example_config.yaml
+++ b/examples/advanced_example_config.yaml
@@ -52,8 +52,8 @@
 
 
 seml:
-  executable: examples/example_experiment.py
-  name: example_experiment
+  executable: examples/advanced_example_experiment.py
+  name: advanced_example_experiment
   output_dir: examples/logs
   project_root_dir: ..
 
@@ -68,79 +68,59 @@ slurm:
 ###### BEGIN PARAMETER CONFIGURATION ######
 
 fixed:
-  max_epochs: 500
-  patience: 10
-  display_step: 25
+  training.patience: 20
+  training.num_epochs: 100
+  optimization:
+    optimizer_type: Adam
 
 grid:
-
-  # SEML supports dot-notation for nested dictionaries.
-  regularization_params.reg_scale:
+  # SEML supports dot-notation for nested parameter dictionaries. E.g., `model.model_type` resolves to
+  # {'model': {'model_type': xxx}}
+  model.model_type:
     type: choice
     options:
-      - 1e-4
-      - 1e-5
+      - variant_1
+      - variant_2
 
-  learning_rate:
+  optimization.regularization.weight_decay:
     type: loguniform
-    min: 1e-5
-    max: 1e-1
-    num: 5
+    min: 1e-6
+    max: 1e-3
+    num: 4
 
 random:
-  samples: 3
-  seed: 821
-
-  regularization_params.dropout:
+  samples: 5
+  seed: 7059
+  model.model_params.dropout:
     type: uniform
     min: 0.0
-    max: 0.7
-    seed: 222
-
-small_datasets:
-
-  grid:
-    dataset:
-      type: choice
-      options:
-        - small_dataset_1
-        - small_dataset_2
-
-    hidden_sizes:
-      type: choice
-      options:
-        - [16]
-        - [32, 16]
-
-  random:
-    samples: 3
-    seed: 2223
-
-    regularization_params.dropout:
-      type: uniform
-      min: 0.0
-      max: 0.7
-      seed: 222
+    max: 0.5
 
 large_datasets:
-
-  fixed:
-    max_epochs: 1000
-
   grid:
-    learning_rate:
-      type: choice
-      options:
-        - 0.001
-
-    dataset:
+    data.dataset:
       type: choice
       options:
         - large_dataset_1
         - large_dataset_2
 
-    hidden_sizes:
+    model.model_params.hidden_sizes:
       type: choice
       options:
         - [64]
         - [64, 32]
+
+
+small_datasets:
+  grid:
+    data.dataset:
+      type: choice
+      options:
+        - small_dataset_1
+        - small_dataset_2
+
+    model.model_params.hidden_sizes:
+      type: choice
+      options:
+        - [32]
+        - [32, 16]

--- a/examples/advanced_example_experiment.py
+++ b/examples/advanced_example_experiment.py
@@ -1,4 +1,10 @@
-import logging
+"""
+This is an advanced experiment example, which makes use of sacred's captured functions with prefixes.
+We wrap all the experiment-specific functionality inside the "ExperimentWrapper" class, and define methods with sacred's
+@ex.capture decorator. This allows a modular design of the configuration, where certain sub-dictionaries (e.g., "data")
+are parsed by a specific method. This avoids having one large "main" function which takes all parameters as input.
+"""
+
 from sacred import Experiment
 import numpy as np
 import seml
@@ -22,18 +28,29 @@ def config():
 
 
 class ModelVariant1:
+    """
+    A dummy model variant 1, which could, e.g., be a certain model or baseline in practice.
+    """
     def __init__(self, hidden_sizes, dropout):
         self.hidden_sizes = hidden_sizes
         self.dropout = dropout
 
 
 class ModelVariant2:
+    """
+    A dummy model variant 2, which could, e.g., be a certain model or baseline in practice.
+    """
     def __init__(self, hidden_sizes, dropout):
         self.hidden_sizes = hidden_sizes
         self.dropout = dropout
 
 
 class ExperimentWrapper:
+    """
+    A simple wrapper around a sacred experiment, making use of sacred's captured functions with prefixes.
+    This allows a modular design of the configuration, where certain sub-dictionaries (e.g., "data") are parsed by
+    specific method. This avoids having one large "main" function which takes all parameters as input.
+    """
 
     def __init__(self, init_all=True):
         if init_all:
@@ -42,6 +59,11 @@ class ExperimentWrapper:
     # With the prefix option we can "filter" the configuration for the sub-dictionary under "data".
     @ex.capture(prefix="data")
     def init_dataset(self, dataset):
+        """
+        Perform dataset loading, preprocessing etc.
+        Since we set prefix="data", this method only gets passed the respective sub-dictionary, enabling a modular
+        experiment design.
+        """
         if dataset == "large_dataset_1":
             self.data = "load_dataset_here"
         elif dataset == "large_dataset_2":
@@ -53,7 +75,8 @@ class ExperimentWrapper:
     @ex.capture(prefix="model")
     def init_model(self, model_type: str, model_params: dict):
         if model_type == "variant_1":
-            # Here we can pass the "model_params" dict to the constructor directly.
+            # Here we can pass the "model_params" dict to the constructor directly, which can be very useful in
+            # practice, since we don't have to do any model-specific processing of the config dictionary.
             self.model = ModelVariant1(**model_params)
         elif model_type == "variant_2":
             self.model = ModelVariant2(**model_params)
@@ -64,6 +87,9 @@ class ExperimentWrapper:
         self.optimizer = optimizer_type  # initialize optimizer
 
     def init_all(self):
+        """
+        Sequentially run the sub-initializers of the experiment.
+        """
         self.init_dataset()
         self.init_model()
         self.init_optimizer()
@@ -72,6 +98,7 @@ class ExperimentWrapper:
     def train(self, patience, num_epochs):
         # everything is set up
         for e in range(num_epochs):
+            # simulate training
             continue
         results = {
             'test_acc': 0.5 + 0.3 * np.random.randn(),
@@ -81,6 +108,8 @@ class ExperimentWrapper:
         return results
 
 
+# We can call this command, e.g., from a Jupyter notebook with init_all=False to get an "empty" experiment wrapper,
+# where we can then for instance load a pretrained model to inspect the performance.
 @ex.command(unobserved=True)
 def get_experiment(init_all=False):
     print('get_experiment')
@@ -88,7 +117,8 @@ def get_experiment(init_all=False):
     return experiment
 
 
-# This function will be called by default.
+# This function will be called by default. Note that we could in principle manually pass an experiment instance,
+# e.g., obtained by loading a model from the database or by calling this from a Jupyter notebook.
 @ex.automain
 def train(experiment=None):
     if experiment is None:

--- a/examples/advanced_example_experiment.py
+++ b/examples/advanced_example_experiment.py
@@ -1,0 +1,96 @@
+import logging
+from sacred import Experiment
+import numpy as np
+import seml
+
+
+ex = Experiment()
+seml.setup_logger(ex)
+
+
+@ex.post_run_hook
+def collect_stats(_run):
+    seml.collect_exp_stats(_run)
+
+
+@ex.config
+def config():
+    overwrite = None
+    db_collection = None
+    if db_collection is not None:
+        ex.observers.append(seml.create_mongodb_observer(db_collection, overwrite=overwrite))
+
+
+class ModelVariant1:
+    def __init__(self, hidden_sizes, dropout):
+        self.hidden_sizes = hidden_sizes
+        self.dropout = dropout
+
+
+class ModelVariant2:
+    def __init__(self, hidden_sizes, dropout):
+        self.hidden_sizes = hidden_sizes
+        self.dropout = dropout
+
+
+class ExperimentWrapper:
+
+    def __init__(self, init_all=True):
+        if init_all:
+            self.init_all()
+
+    # With the prefix option we can "filter" the configuration for the sub-dictionary under "data".
+    @ex.capture(prefix="data")
+    def init_dataset(self, dataset):
+        if dataset == "large_dataset_1":
+            self.data = "load_dataset_here"
+        elif dataset == "large_dataset_2":
+            self.data = "and so on"
+        # ...
+        else:
+            self.data = "..."
+
+    @ex.capture(prefix="model")
+    def init_model(self, model_type: str, model_params: dict):
+        if model_type == "variant_1":
+            # Here we can pass the "model_params" dict to the constructor directly.
+            self.model = ModelVariant1(**model_params)
+        elif model_type == "variant_2":
+            self.model = ModelVariant2(**model_params)
+
+    @ex.capture(prefix="optimization")
+    def init_optimizer(self, regularization: dict, optimizer_type: str):
+        weight_decay = regularization['weight_decay']
+        self.optimizer = optimizer_type  # initialize optimizer
+
+    def init_all(self):
+        self.init_dataset()
+        self.init_model()
+        self.init_optimizer()
+
+    @ex.capture(prefix="training")
+    def train(self, patience, num_epochs):
+        # everything is set up
+        for e in range(num_epochs):
+            continue
+        results = {
+            'test_acc': 0.5 + 0.3 * np.random.randn(),
+            'test_loss': np.random.uniform(0, 10),
+            # ...
+        }
+        return results
+
+
+@ex.command(unobserved=True)
+def get_experiment(init_all=False):
+    print('get_experiment')
+    experiment = ExperimentWrapper(init_all=init_all)
+    return experiment
+
+
+# This function will be called by default.
+@ex.automain
+def train(experiment=None):
+    if experiment is None:
+        experiment = ExperimentWrapper()
+    return experiment.train()

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -69,17 +69,8 @@ slurm:
 
 fixed:
   max_epochs: 500
-  patience: 10
-  display_step: 25
 
 grid:
-
-  # SEML supports dot-notation for nested dictionaries.
-  regularization_params.reg_scale:
-    type: choice
-    options:
-      - 1e-4
-      - 1e-5
 
   learning_rate:
     type: loguniform
@@ -91,6 +82,7 @@ random:
   samples: 3
   seed: 821
 
+  # SEML supports dot-notation for nested dictionaries.
   regularization_params.dropout:
     type: uniform
     min: 0.0
@@ -110,17 +102,16 @@ small_datasets:
       type: choice
       options:
         - [16]
-        - [32, 16]
+        - [32, 16]  # this will be parsed into a Python list.
 
   random:
     samples: 3
     seed: 2223
 
-    regularization_params.dropout:
-      type: uniform
-      min: 0.0
-      max: 0.7
-      seed: 222
+    max_epochs:
+       type: randint
+       min: 200
+       max: 1000
 
 large_datasets:
 

--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -68,8 +68,6 @@ slurm:
 ###### BEGIN PARAMETER CONFIGURATION ######
 
 fixed:
-  reg_scale: 0.0
-  keep_prob: 0.5
   max_epochs: 500
   patience: 10
   display_step: 25
@@ -78,7 +76,6 @@ grid:
   regularization_params:
     type: parameter_collection
     params:
-
       dropout:
         type: choice
         options:
@@ -101,11 +98,14 @@ random:
   samples: 3
   seed: 821
 
-  max_epochs:
-    type: randint
-    min: 200
-    max: 1000
-    seed: 222
+  regularization_params:
+    type: parameter_collection
+    params:
+      dropout:
+        type: uniform
+        min: 0.0
+        max: 0.7
+        seed: 222
 
 small_datasets:
 
@@ -126,21 +126,14 @@ small_datasets:
     samples: 3
     seed: 2223
 
-    reg_scale:
-      type: loguniform
-      min: 1e-9
-      max: 1e-1
-
-    keep_prob:
-      type: uniform
-      min: 0.3
-      max: 1
-
-    patience:
-      type: choice
-      options:
-        - 10
-        - 50
+    regularization_params:
+      type: parameter_collection
+      params:
+        dropout:
+          type: uniform
+          min: 0.0
+          max: 0.7
+          seed: 222
 
 large_datasets:
 

--- a/examples/example_experiment.py
+++ b/examples/example_experiment.py
@@ -23,7 +23,7 @@ def config():
 
 @ex.automain
 def run(dataset, hidden_sizes, learning_rate, max_epochs, patience, display_step,
-        regularization_params):
+        regularization_params: dict):
 
     logging.info('Received the following configuration:')
     logging.info(f'Dataset: {dataset}, hidden sizes: {hidden_sizes}, learning_rate: {learning_rate}, '

--- a/examples/example_experiment.py
+++ b/examples/example_experiment.py
@@ -22,12 +22,12 @@ def config():
 
 
 @ex.automain
-def run(dataset, hidden_sizes, learning_rate, reg_scale, keep_prob, max_epochs, patience, display_step,
+def run(dataset, hidden_sizes, learning_rate, max_epochs, patience, display_step,
         regularization_params):
 
     logging.info('Received the following configuration:')
     logging.info(f'Dataset: {dataset}, hidden sizes: {hidden_sizes}, learning_rate: {learning_rate}, '
-                 f'reg_scale: {reg_scale}, keep_prob:{keep_prob}, max_epochs: {max_epochs}, patience:{patience}, '
+                 f'max_epochs: {max_epochs}, patience:{patience}, '
                  f'display_step: {display_step}, regularization: {regularization_params}')
 
     #  do your processing here

--- a/examples/example_experiment.py
+++ b/examples/example_experiment.py
@@ -22,13 +22,12 @@ def config():
 
 
 @ex.automain
-def run(dataset, hidden_sizes, learning_rate, max_epochs, patience, display_step,
+def run(dataset: str, hidden_sizes: list, learning_rate: float, max_epochs: int,
         regularization_params: dict):
-
+    # Note that regularization_params contains the corresponding sub-dictionary from the configuration.
     logging.info('Received the following configuration:')
     logging.info(f'Dataset: {dataset}, hidden sizes: {hidden_sizes}, learning_rate: {learning_rate}, '
-                 f'max_epochs: {max_epochs}, patience:{patience}, '
-                 f'display_step: {display_step}, regularization: {regularization_params}')
+                 f'max_epochs: {max_epochs}, regularization: {regularization_params}')
 
     #  do your processing here
 

--- a/examples/logs/.gitignore
+++ b/examples/logs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tests/resources/config/config_nested_parameter_collections.yaml
+++ b/tests/resources/config/config_nested_parameter_collections.yaml
@@ -1,0 +1,19 @@
+grid:
+
+  a.b.c:
+    type: choice
+    options:
+      - 999
+      - 1111
+
+  a:
+    type: parameter_collection
+    params:
+      b:
+        type: parameter_collection
+        params:
+          c:
+            type: choice
+            options:
+              - 11
+              - 22

--- a/tests/resources/config/config_with_all_types.yaml
+++ b/tests/resources/config/config_with_all_types.yaml
@@ -1,0 +1,47 @@
+fixed:
+  a: 333
+  b: 444
+
+grid:
+  c:
+    type: choice
+    options:
+      - 555
+      - 666
+
+
+random:
+  samples: 3
+  seed: 333
+  d:
+    type: uniform
+    min: 1
+    max: 1
+
+sub1:
+  fixed:
+    a: 9999
+    b: 7777
+
+  grid:
+    c:
+      type: choice
+      options:
+        - 1234
+        - 5678
+
+  random:
+    samples: 5
+    seed: 9999
+    e:
+      type: uniform
+      min: 2
+      max: 2
+
+sub2:
+  grid:
+    f:
+      type: choice
+      options:
+        - 9199
+        - 1099

--- a/tests/resources/config/config_with_dict_choice.yaml
+++ b/tests/resources/config/config_with_dict_choice.yaml
@@ -1,0 +1,23 @@
+grid:
+  coll1:
+    type: parameter_collection
+    params:
+      a:
+        type: choice
+        options:
+          - sub1: 999
+            sub2: 1919
+          - sub1: 1111
+            sub2: 29292
+
+random:
+  samples: 3
+  seed: 821
+
+  coll1:
+    type: parameter_collection
+    params:
+      b:
+        type: uniform
+        min: 0.0
+        max: 0.7

--- a/tests/resources/config/config_with_duplicate_parameters_1.yaml
+++ b/tests/resources/config/config_with_duplicate_parameters_1.yaml
@@ -1,0 +1,9 @@
+fixed:
+  a: ccc
+
+grid:
+  a:
+    type: choice
+    options:
+      - 1
+      - 2

--- a/tests/resources/config/config_with_duplicate_parameters_2.yaml
+++ b/tests/resources/config/config_with_duplicate_parameters_2.yaml
@@ -1,0 +1,16 @@
+fixed:
+  a:
+    b.c: 333
+
+grid:
+  a:
+    type: parameter_collection
+    params:
+      b:
+        type: parameter_collection
+        params:
+          c:
+            type: choice
+            options:
+              - 11
+              - 22

--- a/tests/resources/config/config_with_duplicate_random_parameters_1.yaml
+++ b/tests/resources/config/config_with_duplicate_random_parameters_1.yaml
@@ -1,0 +1,14 @@
+fixed:
+  seed: 33333
+  samples: 99
+
+
+random:
+  seed: 222
+  samples: 5
+
+  a:
+    type: uniform
+    min: 0
+    max: 1
+    seed: 333

--- a/tests/resources/config/config_with_parameter_collections.yaml
+++ b/tests/resources/config/config_with_parameter_collections.yaml
@@ -1,0 +1,22 @@
+grid:
+  coll1:
+    type: parameter_collection
+    params:
+      a:
+        type: choice
+        options:
+          - 1
+          - 2
+
+random:
+  samples: 3
+  seed: 821
+
+  coll1:
+    type: parameter_collection
+    params:
+      b:
+        type: uniform
+        min: 0.0
+        max: 0.7
+        seed: 333

--- a/tests/resources/config/config_with_parameter_collections_random.yaml
+++ b/tests/resources/config/config_with_parameter_collections_random.yaml
@@ -1,0 +1,26 @@
+grid:
+  coll1:
+    type: parameter_collection
+    params:
+      a:
+        type: choice
+        options:
+          - 1
+          - 2
+
+random:
+  samples: 3
+  seed: 821
+
+  coll1:
+    type: parameter_collection
+    params:
+      b:
+        type: uniform
+        min: 0.0
+        max: 0.7
+
+      c:
+        type: uniform
+        min: 1
+        max: 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,102 @@
+import unittest
+from seml import config, utils
+import yaml
+
+class TestParseConfigDicts(unittest.TestCase):
+
+    SIMPLE_CONFIG_WITH_PARAMETER_COLLECTIONS = "resources/config/config_with_parameter_collections.yaml"
+    SIMPLE_CONFIG_WITH_PARAMETER_COLLECTIONS_RANDOM = "resources/config/config_with_parameter_collections_random.yaml"
+    CONFIG_WITH_DUPLICATE_PARAMETERS_1 = "resources/config/config_with_duplicate_parameters_1.yaml"
+    CONFIG_WITH_DUPLICATE_PARAMETERS_2 = "resources/config/config_with_duplicate_parameters_2.yaml"
+    CONFIG_WITH_DUPLICATE_PARAMETERS_3 = "resources/config/config_nested_parameter_collections.yaml"
+    CONFIG_WITH_DUPLICATE_RDM_PARAMETERS_2 = "resources/config/config_with_duplicate_random_parameters_1.yaml"
+    CONFIG_WITH_ALL_TYPES = "resources/config/config_with_all_types.yaml"
+
+    def load_config_dict(self, path):
+        with open(path, 'r') as conf:
+            config_dict = config.convert_values(yaml.load(conf, Loader=yaml.FullLoader))
+        return config_dict
+
+    def test_convert_parameter_collections(self):
+        config_dict = self.load_config_dict(self.SIMPLE_CONFIG_WITH_PARAMETER_COLLECTIONS)
+        converted = config.convert_parameter_collections(config_dict)
+        expected = {
+            "grid": {
+                'coll1': {
+                    "a": {
+                        "type": "choice",
+                        "options": [1, 2]
+                    }
+                }
+            },
+            "random": {
+                "samples": 3,
+                "seed": 821,
+                "coll1": {
+                    "b": {
+                        "type": "uniform",
+                        "min": 0.0,
+                        "max": 0.7,
+                        "seed": 333,
+                    }
+                },
+            }
+        }
+        self.assertEqual(converted, expected)
+
+    def test_unpack_config_dict(self):
+        config_dict = self.load_config_dict(self.SIMPLE_CONFIG_WITH_PARAMETER_COLLECTIONS)
+        unpacked, next_level = config.unpack_config(config_dict)
+
+        self.assertEqual(next_level, {})
+
+        expected_random = {
+            'samples': 3,
+            'seed': 821,
+            'coll1': {
+                'b': {
+                    'type': 'uniform',
+                    'min': 0.0,
+                    'max': 0.7,
+                    'seed': 333,
+                    # 'samples': 4,
+                }
+            }
+        }
+
+        self.assertEqual(unpacked['random'], expected_random)
+
+    def test_duplicate_parameters(self):
+        config_dict = self.load_config_dict(self.CONFIG_WITH_DUPLICATE_PARAMETERS_1)
+        with self.assertRaises(ValueError):
+            configs = config.generate_configs(config_dict)
+
+        config_dict = self.load_config_dict(self.CONFIG_WITH_DUPLICATE_PARAMETERS_2)
+        with self.assertRaises(ValueError):
+            configs = config.generate_configs(config_dict)
+
+        config_dict = self.load_config_dict(self.CONFIG_WITH_DUPLICATE_PARAMETERS_3)
+        with self.assertRaises(ValueError):
+            configs = config.generate_configs(config_dict)
+
+
+        config_dict = self.load_config_dict(self.CONFIG_WITH_DUPLICATE_RDM_PARAMETERS_2)
+        configs = config.generate_configs(config_dict)
+        assert len(configs) == config_dict['random']['samples']
+
+    def test_generate_configs(self):
+        config_dict = self.load_config_dict(self.CONFIG_WITH_ALL_TYPES)
+        configs = config.generate_configs(config_dict)
+        assert len(configs) == 22
+        expected_configs = [
+            *(5*[{'a': 9999, 'b': 7777, 'c': 1234, 'd': 1.0, 'e': 2.0},
+               {'a': 9999, 'b': 7777, 'c': 5678, 'd': 1.0, 'e': 2.0}]),
+
+            *(3*[{'a': 333, 'b': 444, 'c': 555, 'd': 1.0, 'f': 9199},
+             {'a': 333, 'b': 444, 'c': 555, 'd': 1.0, 'f': 1099},
+             {'a': 333, 'b': 444, 'c': 666, 'd': 1.0, 'f': 9199},
+             {'a': 333, 'b': 444, 'c': 666, 'd': 1.0, 'f': 1099}]),
+        ]
+        expected_config_hashes = sorted([utils.make_hash(x) for x in expected_configs])
+        actual_config_hashes = sorted([utils.make_hash(x) for x in configs])
+        assert expected_config_hashes == actual_config_hashes

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,223 @@
+import unittest
+from seml import utils
+
+
+class TestMergeDictionaries(unittest.TestCase):
+
+    def test_basic(self):
+        d1 = {'a': 3, 'b': 5}
+        d2 = {'b': 99, 'c': 7}
+        merged = utils.merge_dicts(d1, d2)
+        expected = {'a': 3, 'b': 99, 'c': 7}
+        self.assertEqual(merged, expected)
+
+    def test_nested(self):
+        d1 = {'a': 3, 'b': {'c': 10, 'd': 9}}
+        d2 = {'e': 7, 'b': {'c': 99, 'f': 11}}
+        merged = utils.merge_dicts(d1, d2)
+        expected = {'a': 3, 'b': {'c': 99, 'd': 9, 'f': 11}, 'e': 7}
+        self.assertEqual(merged, expected)
+
+    def test_empty(self):
+        d1 = {'a': 3}
+        d2 = {}
+        merged1 = utils.merge_dicts(d1, d2)
+        merged2 = utils.merge_dicts(d2, d1)
+        expected = {'a': 3}
+        self.assertEqual(merged1, expected)
+        self.assertEqual(merged2, expected)
+
+    def test_fails_not_dict(self):
+        d1 = {'a': 3}
+        d2 = ['not_dict']
+        with self.assertRaises(ValueError):
+            merged = utils.merge_dicts(d1, d2)
+        with self.assertRaises(ValueError):
+            merged = utils.merge_dicts(d2, d1)
+
+    def test_nested_non_dict_override(self):
+        d1 = {'a': 3, 'b': {'c': {'d': 4}, 'e': 11}}
+        d2 = {'b': {'c': ['not_dict']}}
+
+        merged1 = utils.merge_dicts(d1, d2)
+        expected1 = {'a': 3, 'b': {'c': ['not_dict'], 'e': 11}}
+        merged2 = utils.merge_dicts(d2, d1)
+        expected2 = {'a': 3, 'b': {'c': {'d': 4}, 'e': 11}}
+
+        self.assertEqual(merged1, expected1)
+        self.assertEqual(merged2, expected2)
+
+
+class TestUnflattenDictionaries(unittest.TestCase):
+
+    def test_basic(self):
+        flattened = {'a.b.c': 111, 'a.d': 22}
+        unflattened = utils.unflatten(flattened, sep=".", recursive=False)
+        unflattened2 = utils.unflatten(flattened, sep=".", recursive=True)  # should not make a difference here
+        expected = {'a': {'b': {'c': 111}, 'd': 22}}
+
+        self.assertEqual(expected, unflattened)
+        self.assertEqual(expected, unflattened2)
+
+    def test_recursive(self):
+        flattened = {'a.b.c': 111, 'a.d': {'e': {'f.g': 333}}}
+        unflattened_recursive = utils.unflatten(flattened, sep=".", recursive=True)
+        expected_recursive = {'a': {'b': {'c': 111}, 'd': {'e': {'f': {'g': 333}}}}}
+        assert unflattened_recursive == expected_recursive
+        self.assertEqual(unflattened_recursive, expected_recursive)
+
+        unflattened_nonrecursive = utils.unflatten(flattened, sep='.', recursive=False)
+        expected_nonrecursive = {'a': {'b': {'c': 111}, 'd': {'e': {'f.g': 333}}}}
+        self.assertEqual(unflattened_nonrecursive, expected_nonrecursive)
+
+    def test_merge_duplicate_keys(self):
+        flattened = {'a.b.c': 111, 'a': {'b': {'d': 222}}}
+        unflattened = utils.unflatten(flattened, sep=".", recursive=True)
+        expected = {'a': {'b': {'c': 111, 'd': 222}}}
+        self.assertEqual(unflattened, expected)
+
+    def test_conflicting_keys(self):
+        flattened = {'a.b.c': 111, 'a.b': {'c': 222}}
+        unflattened = utils.unflatten(flattened, sep='.', recursive=True)
+        expected = {'a': {'b': {'c': 222}}}  # later entries overwrite former ones
+        self.assertEqual(unflattened, expected)
+
+        flattened2 = {'a.b': {'c': 222}, 'a.b.c': 111}   # different order of keys
+        unflattened2 = utils.unflatten(flattened2, sep='.', recursive=True)
+        expected2 = {'a': {'b': {'c': 111}}}
+        self.assertEqual(unflattened2, expected2)
+
+        # this case is actually a bit tricky, but again we follow the paradigm that later entries overwrite former ones.
+        flattened3 = {'a.b': ['not_dict'], 'a.b.c': 111}
+        unflattened3 = utils.unflatten(flattened3, sep='.', recursive=True)
+        expected3 = {'a': {'b': {'c': 111}}}
+        self.assertEqual(unflattened3, expected3)
+
+        # now the other way round
+        flattened4 = {'a.b.c': 111, 'a.b': ['not_dict']}
+        unflattened4 = utils.unflatten(flattened4, sep='.', recursive=True)
+        expected4 = {'a': {'b': ['not_dict']}}
+        self.assertEqual(unflattened4, expected4)
+
+        flattened5 = {'a': {'b': ['not_dict']}, 'a.b.c': 111}
+        unflattened5 = utils.unflatten(flattened5, sep='.', recursive=True)
+        expected5 = {'a': {'b': {'c': 111}}}
+        self.assertEqual(unflattened5, expected5)
+
+        flattened6 = {'a.b.c': 111, 'a': {'b': ['not_dict']}}
+        unflattened6 = utils.unflatten(flattened6, sep='.', recursive=True)
+        expected6 = {'a': {'b': ['not_dict']}}
+        self.assertEqual(unflattened6, expected6)
+
+    def test_unflatten_single_level(self):
+        flattened = {'a.b.c': 111, 'a.b': {'c': 222}}
+        unflattened = utils.unflatten(flattened, sep='.', recursive=True, levels=[-1])
+        unflattened2 = utils.unflatten(flattened, sep='.', recursive=True, levels=-1)
+        expected = {'a.b': {'c': 111}, 'a': {'b': {'c': 222}}}
+        self.assertEqual(unflattened, expected)
+        self.assertEqual(unflattened, unflattened2)
+
+        unflattened3 = utils.unflatten(flattened, sep='.', recursive=True, levels=[0])
+        expected2 = {'a': {'b.c': 111, 'b': {'c': 222}}}
+        self.assertEqual(unflattened3, expected2)
+
+    def test_out_of_bounds(self):
+        flattened = {'a.b.c.d.e': 111, 'a.b.c.d.f': 222, 'a.b.c.g.h': 333}
+        with self.assertRaises(IndexError):
+            unflattened = utils.unflatten(flattened, sep='.', recursive=False, levels=[5])
+
+        with self.assertRaises(IndexError):
+            unflattened = utils.unflatten(flattened, sep='.', recursive=False, levels=[-5])
+
+    def test_errors(self):
+        with self.assertRaises(ValueError):
+            utils.unflatten({}, levels=[])
+
+        with self.assertRaises(TypeError):
+            utils.unflatten({}, levels=1.2)
+
+    def test_empty(self):
+        unflattened = utils.unflatten({})
+        self.assertEqual(unflattened, {})
+
+    def test_recursive_with_levels(self):
+        flattened_base = {'a.b.c.d.e': 111, 'a.b.c.d.f': 222, 'a.b.c.g.h': 333}
+
+        flattened2 = flattened_base.copy()
+        flattened2['a'] = {'b.c.d.e': 777, 'b.c.d.i': 999}
+
+        unflattened = utils.unflatten(flattened2, sep=".", recursive=True, levels=0)
+        expected = {
+            'a': {
+                'b.c.d.e': 111,
+                'b.c.d.f': 222,
+                'b.c.g.h': 333,
+                'b': {
+                    'c.d.e': 777,
+                    'c.d.i': 999,
+                }
+            }
+        }
+        self.assertEqual(unflattened, expected)
+
+        unflattened2 = utils.unflatten(flattened2, sep=".", recursive=False, levels=0)
+        expected2 = {
+            'a': {
+                'b.c.d.e': 777,
+                'b.c.d.f': 222,
+                'b.c.g.h': 333,
+                'b.c.d.i': 999,
+                }
+            }
+        self.assertEqual(unflattened2, expected2)
+
+        with self.assertRaises(IndexError):
+            utils.unflatten(flattened2, sep=".", recursive=True, levels=1)
+
+        with self.assertRaises(IndexError):
+            utils.unflatten(flattened2, sep=".", recursive=False, levels=1)
+
+
+    def test_unflatten_multiple_levels(self):
+        flattened = {'a.b.c.d.e': 111, 'a.b.c.d.f': 222, 'a.b.c.g.h': 333}
+        unflattened = utils.unflatten(flattened, sep='.', recursive=False, levels=[0, -1])
+        expected = {
+            'a': {
+                'b.c.d': {
+                    'e': 111,
+                    'f': 222,
+                },
+                'b.c.g': {
+                    'h': 333,
+                }
+            }
+        }
+        self.assertEqual(unflattened, expected)
+
+        unflattened2 = utils.unflatten(flattened, sep='.', recursive=False, levels=[0, 1, 3])
+        expected2 = {
+            'a': {
+                'b': {
+                    'c.d': {
+                        'e': 111,
+                        'f': 222
+                    },
+                    'c.g': {
+                        'h': 333
+                    }
+                }
+            }
+        }
+        self.assertEqual(unflattened2, expected2)
+
+        unflattened3 = utils.unflatten(flattened, sep='.', recursive=False, levels=[0, 1, 2, 3])
+        expected3 = utils.unflatten(flattened, sep=".", recursive=False)
+        self.assertEqual(unflattened3, expected3)
+
+        unflattened4 = utils.unflatten(flattened, sep='.', recursive=False, levels=[4])
+        self.assertEqual(unflattened4, flattened)
+
+        unflattened5 = utils.unflatten(flattened, sep='.', recursive=False, levels=[-2])
+        expected5 = utils.unflatten(flattened, sep='.', recursive=False, levels=[2])
+        self.assertEqual(unflattened5, expected5)
+


### PR DESCRIPTION



### What does this implement/fix?
Throws an error when the same parameter is re-defined in any two of [`grid`, `fixed`, `random`]. Note that this does **not apply** when the parameter is re-defined in the **same block** (`grid`, `fixed`, or `random`) across levels.

 For example, the following **will** throw an error:
```yaml
fixed:
  param1: 123

sub_config:
  grid:
    param1:
      type: choice
      options:
        - 111
        - 222
```

while the following configuration will not:
```yaml
fixed:
  param1: 123

sub_config:
  fixed:
    param1: 222
```

Moreover, the error message indicates which parameters at which level are conflicting, e.g.:
```
ERROR: Parameters {'param1'} are defined in both 'grid' and 'fixed' in subconfig 'sub_config'.
ERROR: Found duplicate parameters in subconfig named 'sub_config'. Aborting.
```
