### PR TITLE
Improve local workers

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -215,7 +215,7 @@ seml seml_example launch-worker --worker-gpus="1" --worker-cpus=8
 ```
 In this example, the worker will use the GPU with ID 1 (i.e., set `CUDA_VISIBLE_DEVICES="1"`) and can use 8 CPU cores.
 
-The `--local-steal-slurm` option allows local workers to pop experiments from the Slurm queue. Since SEML checks the
+The `--steal-slurm` option allows local workers to pop experiments from the Slurm queue. Since SEML checks the
 database state of each experiment before actually executing it via Slurm, there is no risk of running duplicate 
 experiments.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -204,6 +204,21 @@ seml seml_example start
 ```
 This will start all experiments in the MongoDB collection `seml_example` that currently are in the STAGED state.
 
+## Run experiments locally
+You can also run your experiments locally without Slurm. For this, add the `--local` option:
+```bash
+seml seml_example start --local
+```
+You can even have multiple local workers running jobs in parallel. To add a local worker, run
+```bash
+seml seml_example launch-worker --worker-gpus="1" --worker-cpus=8
+```
+In this example, the worker will use the GPU with ID 1 (i.e., set `CUDA_VISIBLE_DEVICES="1"`) and can use 8 CPU cores.
+
+The `--local-steal-slurm` option allows local workers to pop experiments from the Slurm queue. Since SEML checks the
+database state of each experiment before actually executing it via Slurm, there is no risk of running duplicate 
+experiments.
+
 ### Running multiple experiments per Slurm job
 Often a single experiment requires much less GPU RAM than is available on a GPU. Thus, we can often
 run multiple experiments per Slurm job (which commonly uses a single GPU) to increase the throughput of our experiments.

--- a/examples/notebooks/experiment_results.ipynb
+++ b/examples/notebooks/experiment_results.ipynb
@@ -4,7 +4,16 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/nfs/homedirs/zuegnerd/libraries/seml/seml/database.py:7: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  from tqdm.autonotebook import tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "import seml\n",
     "import pandas as pd\n",
@@ -19,38 +28,54 @@
    },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "HBox(children=(FloatProgress(value=0.0, max=11.0), HTML(value='')))",
       "application/vnd.jupyter.widget-view+json": {
+       "model_id": "373af497df2e440bb7ba65bb735be9a2",
        "version_major": 2,
-       "version_minor": 0,
-       "model_id": "4d84aecfd8bf466b96729d030104a77c"
-      }
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, max=72.0), HTML(value='')))"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\n"
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
     },
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "HBox(children=(FloatProgress(value=0.0, max=11.0), HTML(value='')))",
       "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2c9a3e5d482f4243a743dcebddd2ede1",
        "version_major": 2,
-       "version_minor": 0,
-       "model_id": "0916d1d813a24a038d1471a793bd4812"
-      }
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, max=72.0), HTML(value='')))"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\n"
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/nfs/homedirs/zuegnerd/libraries/seml/seml/evaluation.py:80: FutureWarning: pandas.io.json.json_normalize is deprecated, use pandas.json_normalize instead\n",
+      "  parsed = pd.io.json.json_normalize(parsed, sep='.')\n"
+     ]
     }
    ],
    "source": [
@@ -63,13 +88,147 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "   _id   config.dataset config.db_collection  config.display_step  \\\n0    1  small_dataset_1         seml_example                   25   \n1    2  small_dataset_1         seml_example                   25   \n2    4  small_dataset_1         seml_example                   25   \n3    5  small_dataset_1         seml_example                   25   \n4    6  small_dataset_1         seml_example                   25   \n\n  config.hidden_sizes  config.keep_prob  config.learning_rate  \\\n0                [16]          0.740696               0.00001   \n1                [16]          0.746743               0.00001   \n2            [32, 16]          0.740696               0.00001   \n3                [16]          0.311091               0.00001   \n4            [32, 16]          0.746743               0.00001   \n\n   config.max_epochs  config.overwrite  config.patience  config.reg_scale  \\\n0                334                 1               10      1.087746e-04   \n1                245                 2               50      1.275356e-04   \n2                334                 4               10      1.087746e-04   \n3                827                 5               50      1.338918e-09   \n4                245                 6               50      1.275356e-04   \n\n   config.regularization_params.dropout  \\\n0                                   0.5   \n1                                   0.5   \n2                                   0.5   \n3                                   0.5   \n4                                   0.5   \n\n   config.regularization_params.reg_scale  config.seed  result.test_acc  \\\n0                                  0.0001    430838521         0.601832   \n1                                  0.0001    917107080         0.425274   \n2                                  0.0001    295330006         0.449365   \n3                                  0.0001     65643607         0.179679   \n4                                  0.0001    328060458         0.133723   \n\n   result.test_loss  \n0          7.789576  \n1          9.888527  \n2          2.908617  \n3          6.320316  \n4          8.774114  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>_id</th>\n      <th>config.dataset</th>\n      <th>config.db_collection</th>\n      <th>config.display_step</th>\n      <th>config.hidden_sizes</th>\n      <th>config.keep_prob</th>\n      <th>config.learning_rate</th>\n      <th>config.max_epochs</th>\n      <th>config.overwrite</th>\n      <th>config.patience</th>\n      <th>config.reg_scale</th>\n      <th>config.regularization_params.dropout</th>\n      <th>config.regularization_params.reg_scale</th>\n      <th>config.seed</th>\n      <th>result.test_acc</th>\n      <th>result.test_loss</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>1</td>\n      <td>small_dataset_1</td>\n      <td>seml_example</td>\n      <td>25</td>\n      <td>[16]</td>\n      <td>0.740696</td>\n      <td>0.00001</td>\n      <td>334</td>\n      <td>1</td>\n      <td>10</td>\n      <td>1.087746e-04</td>\n      <td>0.5</td>\n      <td>0.0001</td>\n      <td>430838521</td>\n      <td>0.601832</td>\n      <td>7.789576</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2</td>\n      <td>small_dataset_1</td>\n      <td>seml_example</td>\n      <td>25</td>\n      <td>[16]</td>\n      <td>0.746743</td>\n      <td>0.00001</td>\n      <td>245</td>\n      <td>2</td>\n      <td>50</td>\n      <td>1.275356e-04</td>\n      <td>0.5</td>\n      <td>0.0001</td>\n      <td>917107080</td>\n      <td>0.425274</td>\n      <td>9.888527</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>4</td>\n      <td>small_dataset_1</td>\n      <td>seml_example</td>\n      <td>25</td>\n      <td>[32, 16]</td>\n      <td>0.740696</td>\n      <td>0.00001</td>\n      <td>334</td>\n      <td>4</td>\n      <td>10</td>\n      <td>1.087746e-04</td>\n      <td>0.5</td>\n      <td>0.0001</td>\n      <td>295330006</td>\n      <td>0.449365</td>\n      <td>2.908617</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>5</td>\n      <td>small_dataset_1</td>\n      <td>seml_example</td>\n      <td>25</td>\n      <td>[16]</td>\n      <td>0.311091</td>\n      <td>0.00001</td>\n      <td>827</td>\n      <td>5</td>\n      <td>50</td>\n      <td>1.338918e-09</td>\n      <td>0.5</td>\n      <td>0.0001</td>\n      <td>65643607</td>\n      <td>0.179679</td>\n      <td>6.320316</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>6</td>\n      <td>small_dataset_1</td>\n      <td>seml_example</td>\n      <td>25</td>\n      <td>[32, 16]</td>\n      <td>0.746743</td>\n      <td>0.00001</td>\n      <td>245</td>\n      <td>6</td>\n      <td>50</td>\n      <td>1.275356e-04</td>\n      <td>0.5</td>\n      <td>0.0001</td>\n      <td>328060458</td>\n      <td>0.133723</td>\n      <td>8.774114</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>_id</th>\n",
+       "      <th>config.dataset</th>\n",
+       "      <th>config.db_collection</th>\n",
+       "      <th>config.hidden_sizes</th>\n",
+       "      <th>config.learning_rate</th>\n",
+       "      <th>config.max_epochs</th>\n",
+       "      <th>config.overwrite</th>\n",
+       "      <th>config.regularization_params.dropout</th>\n",
+       "      <th>config.seed</th>\n",
+       "      <th>result.test_acc</th>\n",
+       "      <th>result.test_loss</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>small_dataset_1</td>\n",
+       "      <td>seml_example</td>\n",
+       "      <td>[16]</td>\n",
+       "      <td>0.00001</td>\n",
+       "      <td>519</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.440696</td>\n",
+       "      <td>49592375</td>\n",
+       "      <td>0.738594</td>\n",
+       "      <td>0.333637</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>small_dataset_1</td>\n",
+       "      <td>seml_example</td>\n",
+       "      <td>[16]</td>\n",
+       "      <td>0.00001</td>\n",
+       "      <td>626</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.446743</td>\n",
+       "      <td>912760071</td>\n",
+       "      <td>0.714019</td>\n",
+       "      <td>6.445487</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>small_dataset_1</td>\n",
+       "      <td>seml_example</td>\n",
+       "      <td>[16]</td>\n",
+       "      <td>0.00001</td>\n",
+       "      <td>768</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.011091</td>\n",
+       "      <td>946656409</td>\n",
+       "      <td>0.268248</td>\n",
+       "      <td>8.519550</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>small_dataset_1</td>\n",
+       "      <td>seml_example</td>\n",
+       "      <td>[32, 16]</td>\n",
+       "      <td>0.00001</td>\n",
+       "      <td>519</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0.440696</td>\n",
+       "      <td>488101063</td>\n",
+       "      <td>0.334359</td>\n",
+       "      <td>9.716397</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>small_dataset_1</td>\n",
+       "      <td>seml_example</td>\n",
+       "      <td>[32, 16]</td>\n",
+       "      <td>0.00001</td>\n",
+       "      <td>626</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.446743</td>\n",
+       "      <td>682478206</td>\n",
+       "      <td>0.248766</td>\n",
+       "      <td>8.092757</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   _id   config.dataset config.db_collection config.hidden_sizes  \\\n",
+       "0    1  small_dataset_1         seml_example                [16]   \n",
+       "1    2  small_dataset_1         seml_example                [16]   \n",
+       "2    3  small_dataset_1         seml_example                [16]   \n",
+       "3    4  small_dataset_1         seml_example            [32, 16]   \n",
+       "4    5  small_dataset_1         seml_example            [32, 16]   \n",
+       "\n",
+       "   config.learning_rate  config.max_epochs  config.overwrite  \\\n",
+       "0               0.00001                519                 1   \n",
+       "1               0.00001                626                 2   \n",
+       "2               0.00001                768                 3   \n",
+       "3               0.00001                519                 4   \n",
+       "4               0.00001                626                 5   \n",
+       "\n",
+       "   config.regularization_params.dropout  config.seed  result.test_acc  \\\n",
+       "0                              0.440696     49592375         0.738594   \n",
+       "1                              0.446743    912760071         0.714019   \n",
+       "2                              0.011091    946656409         0.268248   \n",
+       "3                              0.440696    488101063         0.334359   \n",
+       "4                              0.446743    682478206         0.248766   \n",
+       "\n",
+       "   result.test_loss  \n",
+       "0          0.333637  \n",
+       "1          6.445487  \n",
+       "2          8.519550  \n",
+       "3          9.716397  \n",
+       "4          8.092757  "
+      ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 3
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -95,20 +254,20 @@
      "data": {
       "text/plain": [
        "config.dataset   config.hidden_sizes\n",
-       "large_dataset_1  [64, 32]               4.109954\n",
-       "                 [64]                   9.266628\n",
-       "large_dataset_2  [64, 32]               4.087044\n",
-       "                 [64]                   4.843988\n",
-       "small_dataset_1  [16]                   5.210090\n",
-       "                 [32, 16]               4.940274\n",
-       "small_dataset_2  [16]                   4.777097\n",
-       "                 [32, 16]               5.010437\n",
+       "large_dataset_1  [64, 32]               6.082730\n",
+       "                 [64]                   6.708074\n",
+       "large_dataset_2  [64, 32]               4.429962\n",
+       "                 [64]                   5.904191\n",
+       "small_dataset_1  [16]                   5.063250\n",
+       "                 [32, 16]               5.105564\n",
+       "small_dataset_2  [16]                   6.231065\n",
+       "                 [32, 16]               4.949711\n",
        "Name: result.test_loss, dtype: float64"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 5,
      "metadata": {},
-     "execution_count": 5
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -122,12 +281,14 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD8CAYAAABn919SAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvqOYd8AAAFLFJREFUeJzt3W+M5dVdx/HPt8PWDv03mJ2gOyzuPmhWsWs75qZFJ1EC1UWKZbMPbDE0bdXsE/+AodssbU37QLOTYAokGs0GqxhIK6HrlIgVsGNjJIFwhwFX2KK1yp8LyDTN2qYdw7J8fXDv7O7M3r+/f+ec3+/9esLM3du5p797f997zvd8zznm7gIApO9NoRsAACgGAR0AaoKADgA1QUAHgJogoANATRDQAaAmCOgAUBMEdACoCQI6ANTEBVW+2Pbt233Xrl1VviQAJG9lZeU77j476nmVBvRdu3ap3W5X+ZIAkDwze26c55FyAYCaIKADQE0Q0AGgJgjoAFATBHQAqImRAd3Mvmhmr5rZv53z2I+a2cNm9h+9/15UbjMBAKOM00P/K0lXb3nssKSvu/u7JH299zsmtLTa0cLisnYffkALi8taWu2EbhKAhI0M6O7+z5K+u+Xh6yTd1fv5Lkn7C25X7S2tdnTLsePqnFyXS+qcXNctx44T1AFkljWHfrG7v9z7+RVJFw96opkdNLO2mbXX1tYyvlz93Prgs1o/dXrTY+unTuvWB58N1CIAqcs9KerdU6YHnjTt7kfdveXurdnZkStXG+Olk+sTPQ4Ao2QN6P9jZj8uSb3/vlpck5phx8z0RI8DwChZA/r9kj7W+/ljkr5aTHOa49C+PZreNrXpseltUzq0b0+gFgFI3cjNuczsS5KukLTdzF6U9DlJi5LuNbPflPScpF8rs5F1tH9+TlI3l/7SyXXtmJnWoX17zjyOuCytdnivED3rpsCr0Wq1PMbdFrlZMcxGRdK5k9jT26Z05MDeRn9OuG+qY2Yr7t4a9bzGrxSlfBCjUJF0Pu6bODU+oHOzhpXC4ioqks7HfROnxgd0btZwUunlUZF0Pu6bODU+oHOzhpNKL4+KpPNx38Sp8QGdmzWcMnt5RaZy9s/P6ciBvZqbmZZJmpuZbvyEKPdNnCo9UzRGlA+Gs2NmWp0+wTtvL29rVcpGKkdS5vd1//wcn4lzcN/EibJFBFNWOeDC4nLfL4q5mWk9cvjKzH8XCGXcssXG99ARTlm9PCbs0FQEdARVRiqjrFQOELvGT4qifpiwQ1PRQ0ftMGGHpiKgo5aoSkETkXIBgJogoANATRDQAaAmCOgAUBMEdACoCQI6ANQEAR0AaoKADgA1wcIiAMnhgOr+COhICjcyytjvvi5IuSAZqZxBinKlcnRhCPTQc6LHWJ3P3//0wBuZa94c7Hc/GD30HOgxVmdptaOT66f6/hs3crNwQPVgBPQcGPpVZ9g15UZulkP79mjblG16bNuUsd+9COi5MPSrzrBryo3cQFuPQq7uaOSoEdBzYOhXnUHX9KILt5E/b5hbH3xWp97YHMFPveGMjEVAz4Wjzqoz6Fp/7ld/OlCLEAoj48GocsmBo86qw7XGBg4BH8zcq0s+tVotb7fblb0egPrZurBI6o7WjhzYW9sveDNbcffWqOfRQ9+CunIgbozWBssV0M3s9yX9lrpzzMclfcLd/6+IhoXAkuJylP0lyZdw83AIeH+ZJ0XNbE7S70lqufu7JU1J+khRDQuBuvLilb34KtXFXUurHS0sLmv34Qe0sLgcfXuRhrxVLhdImjazCyRdKOml/E0Kh9nz4pX9JVnW3y8z4Kb6JYT4ZU65uHvHzP5Y0vOS1iU95O4PbX2emR2UdFCSLr300qwvVwlmz/Ppl/oo+0uy3/s17PFxlJ16G/YlRBphPKTZ+suTcrlI0nWSdkvaIemtZnbD1ue5+1F3b7l7a3Z2NntLK0BdeXaDep3vnN7W9/lFfUlOmU30+DjKHlUwEsyHEc5geVIuH5D0X+6+5u6nJB2T9PPFNCuM/fNzOnJgr+ZmpmWS5mama10KVaRBQdBMpX5Jnh5Qdjvo8XGUHXBZYZwPc12D5alyeV7S5WZ2obopl6skJV9knsrseWxDzkHB7uQPT+m2D7+3tLbODUiTzeUIjmWn3g7t29O3jrqpI8FJP8uMcAbLk0N/zMzuk/SEpNclrUo6WlTDMFiM5ZXDgmCZX5JlBMeyAy511Gdl+Swz1zUYK0UTtLC4PLBX+sjhKwO0KOzqvTJGK7GNgOoqy2eZlaKDsVI0QTEOOUP2OssYAaSSektdls8yI5zBCOgJinXISRDEpLJ+lvms9cf2uQnKW17JKkXEglLhYtFDT1CeIWeME6poLtInxWJStGFinFAFMNy4k6KkXBomxglVAMUgoDcMqxSB+iKgNwyTUEB9MSnaMExCAfVFQG8ganiBeiKgo3JFLKtnaT5wPgI6KlVEHTy19EB/TIqiUkXsZZ36ftis1EVZ6KGjUkXUwadcS8/oAmWih45KFVEHn3ItfeqjC8SNgI5KFVEHn3ItfcqjC8SPlAsqVUQdfMq19LFufYx6YHMuoEJNPG0H+XFiERChlEcXiB8BHagYK3VRFiZFAaAmCOgAUBMEdACoCQI6ANQEk6Jg50KgJgjoDcfeIkB9kHJpOPYWAeqDgN5wg/YQ6ZxcZ1tXIDEE9IYbtofILceOE9SBhBDQG67fzoUbSL0AaWFStOE2Jj5v+psn+/4727oC6cjVQzezGTO7z8y+aWYnzOznimoYqrN/fk5zCR8aAaArb8rlDkn/4O4/Kek9kk7kbxJCSPnQCABdmVMuZvZOSb8g6eOS5O6vSXqtmGalLcWFOmzrCqQvTw59t6Q1SX9pZu+RtCLpRnf/QSEtS1TKC3XY1hVIW56UywWSflbSn7n7vKQfSDq89UlmdtDM2mbWXltby/FyaWChDoANS6sdLSwua/fhB7SwuFx6GXCegP6ipBfd/bHe7/epG+A3cfej7t5y99bs7GyOl0sDhwADkM6O1jsn1+U6O1ovM6hnDuju/oqkF8xsY9bsKknPFNKqhA2qCqFaBGiWEKP1vHXovyvpHjN7s6RvS/pE/ial7dC+PX0PAaZaJJ8UJ5qbiPfprBCj9VwB3d2flDTyJOomoVpktElv+pQnmpuE92mzHTPT6vQJ3mWO1lkpWhB6JuPJctMPG7pyjePB+7RZiNE6Ab0A9EzGl+WmZ6I5DqM6LbxPm4UYrRPQC0DPZHxZbvoQQ1dsNk6nhffpfFWv7WC3xQLQMxlfliogtiUIb5yKDd6n8AjoBaBUcXxZbvr983M6cmCv5mamZZLmZqZ15MBeRj8VGqfTwvsUHimXAlCqOL6seUW2JQhr3HQK71NYBPQCUKo4mdRueiqY6LSkgoBekNSCFMZDBVMXnZY0ENCBIahgOotOS/yYFAWGoIIJKSGgA0NQwYSUENCBIaitRkrIoQNDMBkYFyqOhiOgAyMwGRgHKo5GI+UCIAkc7zgaAR1AEqg4Go2UCxAQOeHxsZvjaPTQgUBCHCKcMiqORqOHDgTCKtTJZK04atIoiIAOBEJOeHKTVhw1rTKGlAsQCKtQy9e0yhgCOhAIOeHyNW0URMoFCCTvKtRUc8NVtrtplTEEdCCjIgJT1lWoqeaGq2530w7mSD7lsrTa0cLisnYffkALi8uUfKESoUsOU80NV93upp1zmnQPPdVeCtIXuuQw1dxwiHY3aS+epHvoqfZSkL7QATXVCplU252KpAN66JsKzRU6MKVaIZNqu1ORdEAPfVOhuUIHplRzw6m2OxXm7pW9WKvV8na7Xdjf25pDl7o3FR8QVCHVskGkx8xW3L016nlJT4pymgxCatJkG9KQdECXuKmqVnWvlF4wML7cAd3MpiS1JXXc/dr8TUKsqi4TpSwVmEwRk6I3SjpRwN9B5KouE6UsFZhMroBuZpdI+qCkO4tpDmJWdZkoZanAZPL20G+X9ClJbxTQFkSu6jJRylKByWQO6GZ2raRX3X1lxPMOmlnbzNpra2tZX65U7Acznqprr0PXegOpyTMpuiDpQ2Z2jaS3SHqHmd3t7jec+yR3PyrpqNStQ8/xeqVg4m18VZeJUpYKTKaQhUVmdoWkT46qcil6YVERFhaX++6XPDczrUcOXxmgRQCw2bgLi5Je+l8EJt4A1EUhC4vc/RuSvlHE36pa0040QVgslEKZGt9DZ+INWWSZSA99KAbqL/ml/3kx8YZJZZ1IL+JQDHr4GKbxAV1iPxhMJmtgzjtfQ0UWRok+oNMjQUj9Pn9ZA3Pe+ZrQx94hflHn0Mk5IqRBn7+ZC7f1ff6owJx3voaKLIwSdUBncyaENOjz565MgTnvaT1shYBRok650CNBSIM+Z/+7fkq3ffi9mVKBeeZrDu3b0/eELiqysCHqgE6NOEIa9vkLMZFORRZGiTqg0yNBSDF+/qjIwjBRB3R6JAiJzx9SU8jmXOOKcXMuAIgdm3MBQMNEnXJBM7B4rFhcz+YioCMolrMXi+vZbKRcEBSLx4rF9Ww2AjqCYvFYsbiezUZAR1AsZy8W17PZCOgIigNGisX1bDYmRbFJ1RUSLN4pFtez2VhYhDO2VkhI3d7dJDsCAigeC4swMSokgLQR0HEGFRJA2gjoOIMKCSBtBHScQYUEkDaqXHAGFRJA2gjo2IQDFDAuNgGLDwEdjUEAKg6bgMWJHDoaYSMAdU6uy3U2AC2tdkI3LUmUuMaJHjqiU0ZPelgAokc5OUpc40RAR1TKGsrnCUCkas63Y2ZanT7XjhLXsEi5ICplDeWz1tjXPVWztNrRwuKydh9+QAuLy2P//6LENU4EdESlrKF81gBU51xxni+r/fNzOnJgr+ZmpmWS5mam2fMnAplTLma2U9JfS7pYkks66u53FNUwNFNZQ/msNfZ1zhXnnVfIUuJK+qpceXLor0u62d2fMLO3S1oxs4fd/ZmC2oYGOrRvT98dH4sYymcJQIO+YN5kpqXVTtLBqOovK0ody5c55eLuL7v7E72fvy/phCTeFeQS21C+X6pGkk67J59Lr3rvnjqnr2JRSJWLme2SNC/psSL+HpotptWqG+24+d6ndHrL2QGplz2WORrqJ8SIoGnpndyTomb2NklfkXSTu3+vz78fNLO2mbXX1tbyvhxQuf3zc3pjwEEwKefSqx4NVTkiKKI6KWsFUEi5euhmtk3dYH6Pux/r9xx3PyrpqNQ9sSjP6wGh1LXuusrRUJUjgrwTvqnm+zP30M3MJP2FpBPu/oXimgTEh7rr/KocEeRN76Sa78/TQ1+Q9FFJx83syd5jn3b3v8/fLCAubC1cjKpGBHlHVKmWq2YO6O7+L5KswLYAlfjs0nF96bEXdNpdU2a6/v079Yf7947838U0WYvh8qZ3Uk2xsVIUjbG02tFP/cHXdPejz5+pWDntrrsffV6fXToeuHUoUt70TqopNvMBs/dlaLVa3m63K3s9YMPWSa6tpsz0n0euqbhViFlMZY9mtuLurVHPY7dFNEK/Sa5zba0xB1JMsZFyQSOMmsyaMqaDkD4COhph1GTW9e/fWVFLgPIQ0NEIg/ZkeZNJN1x+6VhVLkDsyKGjEcqsI49p8gzNRkBHY5QxyZXqEnHUEwEdOMekvW0On0ZMCOhAT5bedqpLxFFPTIoCPVk2ZKr6kAhgGAI60JOlt53qEnHUEwEd6MnS247tyDw0Gzl0oCfrDn0pLhFHPRHQgR72PEfqCOjAOehtI2Xk0AGgJgjoAFATBHQAqAly6EAF2MArfnV4jwjoQMmybClQh+CSkrpsskbKBSjZpFsKbASXzsl1uc4Gl6XVTgWtbaYs2z7EiIAOlGzSLQXqElxSUpdN1gjoQMkm3VKgLsElJXXZZI2ADpRs0g286hJcUlKXTdYI6EDJJt3Aa9D5pz987XXy6CWpyyZr5u6VvVir1fJ2u13Z6wGpWlrt6PP3P62T66c2PT69bSrJQBOb1KqIzGzF3VujnkcPHYjQ/vk5vfVHzq8qZnI0vzpXERHQgUgxOVqOOlcREdCBSDE5Wo46f1ES0IFI1aXyIjZ1/qIkoAORqkvlRWzq/EWZay8XM7ta0h2SpiTd6e6LhbQKgCQO3ChDnU+myhzQzWxK0p9K+iVJL0p63Mzud/dnimocAJShrl+UeVIu75P0LXf/tru/JunLkq4rplkAgEnlCehzkl445/cXe48BAAIofVLUzA6aWdvM2mtra2W/HAA0Vp6A3pG085zfL+k9tom7H3X3lru3Zmdnc7wcAGCYPAH9cUnvMrPdZvZmSR+RdH8xzQIATCrX5lxmdo2k29UtW/yiu//RiOevSXpuyFO2S/pO5gbVH9dnOK7PcFyf4WK+Pj/h7iNTHJXutjiKmbXH2VGsqbg+w3F9huP6DFeH68NKUQCoCQI6ANREbAH9aOgGRI7rMxzXZziuz3DJX5+ocugAgOxi66EDADKKNqCb2c1m5ma2PXRbYmJmt5rZN83sX83sb81sJnSbYmBmV5vZs2b2LTM7HLo9MTGznWb2T2b2jJk9bWY3hm5TjMxsysxWzezvQrclqygDupntlPTLkp4P3ZYIPSzp3e7+M5L+XdItgdsT3Dk7f/6KpMskXW9ml4VtVVRel3Szu18m6XJJv8316etGSSdCNyKPKAO6pNskfUoSCf4t3P0hd3+99+uj6m650HTs/DmEu7/s7k/0fv6+ukGLjfTOYWaXSPqgpDtDtyWP6AK6mV0nqePuT4VuSwJ+Q9LXQjciAuz8OSYz2yVpXtJjYVsSndvV7US+EboheeQ6sSgrM/tHST/W558+I+nT6qZbGmvY9XH3r/ae8xl1h9L3VNk2pMvM3ibpK5JucvfvhW5PLMzsWkmvuvuKmV0Ruj15BAno7v6Bfo+b2V5JuyU9ZWZSN53whJm9z91fqbCJQQ26PhvM7OOSrpV0lVN3Ko2582eTmdk2dYP5Pe5+LHR7IrMg6UO9vaneIukdZna3u98QuF0Ti7oO3cz+W1LL3WPdMKdyvXNcvyDpF92dDeYlmdkF6k4QX6VuIH9c0q+7+9NBGxYJ6/aO7pL0XXe/KXR7YtbroX/S3a8N3ZYsosuhY6Q/kfR2SQ+b2ZNm9uehGxRab5L4dyQ9qO6E370E800WJH1U0pW9z8yTvd4oaibqHjoAYHz00AGgJgjoAFATBHQAqAkCOgDUBAEdAGqCgA4ANUFAB4CaIKADQE38PwIPv0uc1HnEAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD4CAYAAAD1jb0+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAAV/0lEQVR4nO3df5Bd5V3H8c+3STougi6YhZIF3NSpQaRicFVs2k6FzoRfU2KnOrRCkcHJdBwrdZzo0v5R/7KrOJ3W0dHJUCwOTFFpJsUBpUiqKBXshlB+RVoolLLEsljSdmiUJP36x73b3OzeH+eec55znuec92uGyebuzd4ve+/5nud8n+/zHHN3AQDS87q6AwAA5EMCB4BEkcABIFEkcABIFAkcABK1tsoXW79+vc/MzFT5kgCQvL17977s7lMrHx+ZwM3sZkmXS3rJ3c/tPnaKpL+VNCPpOUm/5u6vjPpZMzMzWlhYGC9yAGg5M/t6v8ezlFA+LeniFY/NSbrP3d8k6b7u3wEAFRqZwN39fknfWvHwFZJu6X59i6Rt5YYFABgl7yTmae5+QJK6f5466Ilmtt3MFsxsYWlpKefLAQBWCt6F4u473X3W3WenplbV4AEAOeVN4N80s9MlqfvnS+WFBADIIm8b4Z2SrpE03/3zc6VFhNbavW9RN97zlF48eEgbJie0Y+smbds8XXdYQLSytBF+RtI7JK03sxckfVSdxP13ZnadpOcl/WrIINF8u/ct6oZdj+nQ4aOSpMWDh3TDrsckqbQkHvIEwckHdRiZwN39vQO+dVHJsaDFbrznqR8k72WHDh/Vjfc8VUoiDHmCqOLkA/TDUnpE4cWDh8Z6fFzDThAx/+yU7N63qC3ze7Rx7i5tmd+j3fsW6w6p8UjgiMKGyYmxHh9XyBNE6JNPCpavQhYPHpLr2FUISTwsEjiisGPrJk2sW3PcYxPr1mjH1k0D/804I76QJ4jQJ58UcBVSDxI4orBt87Q+9u43a3pyQiZpenJCH3v3mwfWkMcd8eU5QWQV8menouhVCOWXfCrdjRAYZtvm6cyTfuNOei4/FqJTJOTPTsWGyQkt9knWWa5CmATOjwSOJOUZ8Y1zghhXyJ+dgh1bNx2XhKXsVyGhO5CajBIKkkTdOS7jlsB6MQmcHyNwJKnIiA9h5L0KKVJ+aTtG4EhSkREf4sIkcH6MwJGsttedm4JJ4PxI4ABqx8k4H0ooAJAoRuBAhdi1EGUigQMVYcEKykYJBagI+4WgbCRwoCIsWEHZSOBARVg9irKRwIGKsGAFZWMSE6gIC1ZQNhI4UCEWrKBMJHAUQl8zUB8SOHKjrxmoFwkcuY3qa059ZF706oKrE4RGAkdug/qXl0fiKY/Mi15dcHWCKtBGiNwG9S+vMUt+xWHRVZOsukQVSODIbVBf81H3vs9PacVh0VWTrLpEFUjgyG3QXXGmK1pxuHvforbM79HGubu0ZX6Pdu9bLO1nF101yapLVIEaOAoZ1Ncc+n6VoWvMRe+5yT07UQUSOEoXYsXhyo6O7712ZGCNuYwEXvT/gVWXWBayG8l8QL0yhNnZWV9YWKjs9dAMK0fbw5ikZ+cvCx8UkEG/z+7EujVj34DbzPa6++zKx6mBI3r9OjoGocaMmITuRqKEglKEvEzM2rlBjRmxCd2NxAgchS1fJi4ePCTXsQnFsrpCBo2qJyfWreqAocaMmITuRio0Ajez35X0m5Jc0mOSrnX3/y0jMKRj2GViyI6QP3zXT5OwEbXQ3Ui5R+BmNi3pdyTNuvu5ktZIurKUqJCU0JeJg/rNSd6IXejPbtEa+FpJE2Z2WNIJkl4sHhJSs2FyQot9knWZE4rso41Uhfzs5h6Bu/uipD+V9LykA5K+7e6fX/k8M9tuZgtmtrC0tJQ/UkSLW4UB9cg9AjezkyVdIWmjpIOS/t7MrnL3W3uf5+47Je2UOn3g+UNFVcbtKGHRSv3q2LqW7XLrV6SE8k5Jz7r7kiSZ2S5Jb5F069B/hajlXaJOiaM+dWxdy3a5cSjSRvi8pAvM7AQzM0kXSdpfTlioC9ugZhNyI61x1fGe8TmJQ+4RuLs/ZGZ3SHpY0hFJ+9QtlSBdbIM6WmyjzzreMz4ncSi0kMfdP+ruZ7v7ue5+tbv/X1mBoR5sgzpabKPPOt4zPidxYCUmjkNHyWghRp9FSjJ1vGd8TuLAXig4Ths6Sop2T5Td9160JFPHe9aGz0kK2E4WrVLG9p5lbRG6bMv8nr4nhOnJCT0wd+HYPy9ltCb2N2g7WUbgaJUy9m0pe/QZ64Rg1ck0tsnhFESfwDkjo0xlJcsy+96r2IpgXHUk09CbojVR1JOYobcpRfvE2D0RckIw7+Rolk6bsnvhY70SiVnUCTy2di2kL8buiVA71hUZAI1KpiEGVzGeXGMXdQmFMzLKFmv3RIitCIqUJEaVdUKUO0Lvnd1EUSfwGGuDSF9b9m0pMgAalUxDDK5iPbnGLOoEzhkZyK/IAGhUMg01uGrLybUsUSdwzshAfkUHQMOSKYOrOESdwCXOyEBeIQdADK7iwEpMAIjcoJWYUbcRAgAGI4EDQKKir4EDWI0tJiCRwIHksOkTllFCARLDFhNYxggc0aJM0B9bTGAZCRxRakKZINQJiC0msIwSCqKUepkg5FbIMe6oiHqQwBGl1MsEIU9AobafRXoooSBKecsEsdTNQ5+A2GICEgkcY6oqQebZLCmmunlT69SxnCDRQQkFmVV5i7s8ZYKY6uYx3iatjNflFodxYQSOzKq+6ey4ZYKY6uahduur8yqDmw7HhwSOzGJKkP3EVraI7TZpRcX+/rcRJRRkFvtNZ9vQXldnEo39/W8jEjgyiz1BtqG9rs4kGvv730aUUJBZCndhaXp7XZ23Mkvh/W8b7sgDJIZWvvYZdEceRuBolDYkt6ZdZbThPQuFBI5cYjzoYlrIg2x4z4opNIlpZpNmdoeZ/ZeZ7TezXyorMMQr1gUdMS3kQTa8Z8UU7UL5pKR/cvezJZ0naX/xkBC7WA86+pTTw3tWTO4Sipn9iKS3S/oNSXL31yS9Vk5YiMnKckm/xTJS/QddbAt5MBrvWTFFRuBvlLQk6a/NbJ+Z3WRmP1xSXIhEv3KJDXhu3Qcdfcrp4T0rpkgCXyvpfEl/6e6bJb0qaW7lk8xsu5ktmNnC0tJSgZdDHfqVS1xalcRjOOjasJCnaXjPisndB25mb5D0oLvPdP/+Nklz7n7ZoH9DH3h6Ns7dpUGfkOnJiai6UICmKr0P3N3/28y+YWab3P0pSRdJerJIkIjPoBrl9OSEHpi7sIaIACwr2oXyQUm3mdmjkn5W0h8VjghRoUYJxKvQQh53f0TSqmE9moP9L4B4sRITIzVt6TbQFCRwAJnEuH1C25HAgYTUlUTZsyRO3NABSESde9DEun1C25HAgUTUmUTZsyROJHAgEdwPEyuRwCO2e9+itszv0ca5u7Rlfk/t27WiXtwPEyuRwCMV657bqE+dSZQ9S+JEF0qkhtU7OWjaqe5FVawHiA8JPFJMGqEfkih6UUKJFJNGAEYhgUeKSSNkxWR3e1FCiVTd9U6kgRWS7UYCjxj1TozCZHe7UUIBEsZkd7uRwIGEMdndbiRwIGFMdrcbNXAgYUx2txsJHEgck93tRQkFABJFAgeARJHAASBR1MBbjJvUFsPvD3UjgbcUS7CL4feHGFBCaSluUlsMvz/EgBF4S7EEu5jFAb+nQY+DklMIJPCW2jA50TfZsAQ7mzVmOure9/EyNC3ZUXIKgxJKS7EEu5h+yXvY4+No4v1QKTmFQQJvKW5SW8z0gCuVQY+Po4nJjpJdGJRQWowl2Pnt2LrpuJKAVN4VTBOTHSW7MBiBAzmEvIJp4haxlOzCYASORlueDFw8eOgHE4/TJU0KhrqCCTm6rwu7JoZBAkdjrex8WJ5gjL0DoqnJjpJd+UjgaKx+k4HLYr9vJMkOWRRO4Ga2RtKCpEV3v7x4SEA5Rk36pTwpiGOa1jM/jjImMa+XtL+EnwOUatSk3+vMku6tRjN75sdRKIGb2RmSLpN0UznhAOXp1/nQ66h7qw72Jmpiz/w4io7APyHp9yV9f9ATzGy7mS2Y2cLS0lLBlwOy6231G6RNB3sTNbFnfhy5E7iZXS7pJXffO+x57r7T3WfdfXZqairvywG5bNs8rQfmLtRz85dp0C4lbTnYm6iJPfPjKDIC3yLpXWb2nKTbJV1oZreWEhUQQNsP9iZq+wKh3Anc3W9w9zPcfUbSlZL2uPtVpUUGlKztB3sTtX1PH/rA0RpNXSDTdm3umTcvYfvLrGZnZ31hYaGy1wNS1ub+ZhzPzPa6++zKxxmBB8CBh6KqvgECn9k0sRthydq+sADlqLK/mc9sukjgJWv7wgKUo8r+Zj6z6SKBl6ztCwtQjipbHvnMposEXjJ6jVGGKlse+cymiwReMnqNUYYq+5v5zKaLLpSS0WuMslTV38xnNl30gQNA5Ab1gVNCAYBEkcABIFEkcABIFJOYCI5l2kAYJHAEVfWeHkCbkMAR1LBl2iTwbLiCwSAkcATFMu1iuILBMExiIiiWaRfDRlMYhgSOoFimXQxXMBiGBI6g2n7PwqK4gsEw1MARXJvvWVjUjq2bjquBS1zB4BgSOBAxNprCMCRwIHJcwWAQauAAkChG4EABLLJBnUjgQE4sskHdKKEAObHIBnVjBI4opVCaYJEN6sYIHNFZLk0sHjwk17HSxO59i3WHdhwW2aBuJHBEJ5XSRF3bBOzet6gt83u0ce4ubZnfE92JDdWhhILopFKaqGORDROn6EUCR3Q2TE5osU+yDlWaKFJvr3qRDfuroxclFESnytJEKvX2ZalcnaAaJHBEZXk0fOjwUVnP4z+0LsxHNZV6+zImTtGLBI5o9I6GJcl7vvfK9w4HGRmnNqJlf3X0yp3AzexMM/uCme03syfM7PoyA0P79BsN9woxMs47oq2rE4T91dGryCTmEUm/5+4Pm9lJkvaa2b3u/mRJsaFlsox6yx4Z59lvu+5OEHYnxLLcI3B3P+DuD3e//q6k/ZKS+1TRUxuPLHXcsmu9eUa0qdXN0VyltBGa2YykzZIe6vO97ZK2S9JZZ51VxsuVpu6RFI7XbzTcK1Std9wRbWp1czRX4UlMMztR0mclfcjdv7Py++6+091n3X12amqq6MuVipFUXFaOhicn1unkE9ZFV+ulEwSxKDQCN7N16iTv29x9VzkhVYeRVHxSqO9yn0rEokgXikn6lKT97v7x8kKqDiMp5EEnCGJRZAS+RdLVkh4zs0e6j33Y3e8uHFVFGEkhrxSuFNB8uRO4u/+7dNxiueRwx2+kIoX90VG91m9mxUgKsaNbCoOwlB6IHN1SGIQEDkSObikM0voSSpNQJ22mqvdHRzoYgTdEavtaIzt2IMQgJPCGoE7aXPSdYxBKKA1BnbTZ6JZCP4zAG4JVpUD7kMAbgjppc7HlMQahhNIQrCptJhbxYBgSeINQJz2mKS2VwyanU/z/QblI4GicJo1amZzGMNTA0ThNaqlkchrDkMDROE0atTI5jWFI4GicJo1aWcSDYaiBo3GadqMOJqcxCAkcjUNLJdqCBI5GYtSKNiCBA6hFU3r160QCB1C5JvXq14kEjigwGmsXVpiWgwSO2jEaa58m9erXiT5w1K5JKyeRTZN69etEAkdQWbZCZTTWPqwwLQclFASTtTTCTXvbh179cpDAEUzWiaqmrZzsxeTsYPTqF0cCRzBZSyNNHY1VNTnLSaK9SOAIZpzSSBNHY1W0ytHB025MYiKYtk9UVTE5SwdPu5HAEUzbt0KtolWODp52o4SCoJpYGsmqislZOnjajRE4EEgVVyBtL1O1HSNwIKDQVyBN7eBBNoUSuJldLOmTktZIusnd50uJCkBmbS5TtV3uEoqZrZH0F5IukXSOpPea2TllBQYAGK5IDfwXJD3t7l9z99ck3S7pinLCAgCMUiSBT0v6Rs/fX+g+dhwz225mC2a2sLS0VODlAAC9iiRw6/OYr3rAfae7z7r77NTUVIGXAwD0KpLAX5B0Zs/fz5D0YrFwAABZmfuqQXO2f2i2VtJXJF0kaVHSlyS9z92fGPJvliR9PdcLlmu9pJfrDmIAYssn1thijUsitrzqiO3H3X1VCSN3G6G7HzGz35Z0jzpthDcPS97dfxNFDcXMFtx9tu44+iG2fGKNLda4JGLLK6bYCvWBu/vdku4uKRYAwBhYSg8AiWprAt9ZdwBDEFs+scYWa1wSseUVTWy5JzEBAPVq6wgcAJJHAgeARLUigZvZKWZ2r5l9tfvnyX2ec6aZfcHM9pvZE2Z2feCYLjazp8zsaTOb6/N9M7M/637/UTM7P2Q8Y8b2692YHjWzL5rZeTHE1fO8nzezo2b2niriyhqbmb3DzB7pfr7+NZbYzOxHzewfzOzL3diurSium83sJTN7fMD36zwGRsVWyzGwirs3/j9JfyJprvv1nKQ/7vOc0yWd3/36JHUWKZ0TKJ41kp6R9EZJr5f05ZWvJelSSf+ozpYFF0h6qKLfVZbY3iLp5O7Xl1QRW5a4ep63R5321vdE9DublPSkpLO6fz81otg+vHxMSJqS9C1Jr68gtrdLOl/S4wO+X8sxkDG2yo+Bfv+1YgSuzi6Jt3S/vkXStpVPcPcD7v5w9+vvStqvPptzlSTLTo5XSPob73hQ0qSZnR4onrFic/cvuvsr3b8+qM42CrXH1fVBSZ+V9FIFMY0T2/sk7XL35yXJ3auKL0tsLukkMzNJJ6qTwI+EDszd7+++1iB1HQMjY6vpGFilLQn8NHc/IHUStaRThz3ZzGYkbZb0UKB4suzkmGm3xwDGfd3r1BklhTYyLjOblvQrkv6qgnh6Zfmd/aSkk83sX8xsr5m9P6LY/lzST6mzl9Fjkq539+9XE95QdR0D46rqGFilMbdUM7N/lvSGPt/6yJg/50R1RnAfcvfvlBFbv5fp89jKfs5Muz0GkPl1zeyX1fnwvjVoRN2X6/PYyrg+IekP3P1oZzBZmSyxrZX0c+rsHTQh6T/M7EF3/0oEsW2V9IikCyX9hKR7zezfAn7+s6rrGMis4mNglcYkcHd/56Dvmdk3zex0dz/QvQTre/lqZuvUSd63ufuuQKFK2XZyrGu3x0yva2Y/I+kmSZe4+/9EEtespNu7yXu9pEvN7Ii7744gthckvezur0p61czul3SeOnMtdcd2raR57xR0nzazZyWdLek/A8c2StQ7ntZwDKzSlhLKnZKu6X59jaTPrXxCt/73KUn73f3jgeP5kqQ3mdlGM3u9pCu7Mfa6U9L7uzPxF0j69nIZqO7YzOwsSbskXV3BCDJzXO6+0d1n3H1G0h2SfquC5J0pNnU+c28zs7VmdoKkX1RnniWG2J5X58pAZnaapE2SvlZBbKPUdQyMVNMxsFodM6dV/yfpxyTdJ+mr3T9P6T6+QdLd3a/fqs7l2aPqXE4+IunSgDFdqs7o6xlJH+k+9gFJH+h+bercc/QZdeqSsxX+vkbFdpOkV3p+TwsxxLXiuZ9WRV0oWWOTtEOdTpTH1SnRRRFb9zj4fPdz9rikqyqK6zOSDkg6rM5o+7qIjoFRsdVyDKz8j6X0AJCotpRQAKBxSOAAkCgSOAAkigQOAIkigQNAokjgAJAoEjgAJOr/AUIJl9xnHLXHAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -135,13 +296,20 @@
     "plt.scatter(results['result.test_acc'], results['result.test_loss'])\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.3 64-bit",
+   "display_name": "Python (torch)",
    "language": "python",
-   "name": "python37364bit9058597f1b7b476eaa274990d45fb9ee"
+   "name": "torch"
   },
   "language_info": {
    "codemirror_mode": {
@@ -153,7 +321,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3-final"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/seml/main.py
+++ b/seml/main.py
@@ -117,18 +117,6 @@ def main():
     parser_start_launch_parent.add_argument(
             '-we', '--worker-environment-vars', type=json.loads,
             help="Further environment variables to be set for the local worker. Has no effect for Slurm jobs.")
-    parser_start_launch_parent.add_argument(
-            '-u', '--unobserved', action='store_true',
-            help="Run the experiments without Sacred observers (no changes to the database). "
-                 "This also disables output capturing by Sacred, facilitating the use of debuggers (pdb, ipdb).")
-    parser_start_launch_parent.add_argument(
-            '-d', '--debug', action='store_true',
-            help="Run a single experiment locally without Sacred observers and with post-mortem debugging. "
-                 "This is equivalent to "
-                 "`--verbose --local --num-exps 1 --set_to_pending --post-mortem --output-to-console`.")
-    parser_start_launch_parent.add_argument(
-            '-dr', '--dry-run', action='store_true',
-            help="Only show the associated commands instead of running the experiments.")
 
     parser_start = subparsers.add_parser(
             "start",
@@ -140,14 +128,26 @@ def main():
     parser_start.add_argument(
             '-nw', '--no-worker', action='store_true',
             help="Do not launch a local worker after setting experiments' state to PENDING.")
-
+    parser_start.add_argument(
+            '-u', '--unobserved', action='store_true',
+            help="Run the experiments without Sacred observers (no changes to the database). "
+                 "This also disables output capturing by Sacred, facilitating the use of debuggers (pdb, ipdb).")
+    parser_start.add_argument(
+            '-d', '--debug', action='store_true',
+            help="Run a single experiment locally without Sacred observers and with post-mortem debugging. "
+                 "This is equivalent to "
+                 "`--verbose --local --num-exps 1 --set_to_pending --post-mortem --output-to-console`.")
+    parser_start.add_argument(
+            '-dr', '--dry-run', action='store_true',
+            help="Only show the associated commands instead of running the experiments.")
     parser_start.set_defaults(func=start_experiments, set_to_pending=True)
 
     parser_launch_worker = subparsers.add_parser(
         "launch-worker",
         parents=[parser_start_launch_parent],
         help="Launch a local worker that runs PENDING jobs.")
-    parser_launch_worker.set_defaults(func=start_experiments, set_to_pending=False, no_worker=False, local=True)
+    parser_launch_worker.set_defaults(func=start_experiments, set_to_pending=False, no_worker=False, local=True,
+                                      unobserved=False, debug=False, dry_run=False)
 
     parser_status = subparsers.add_parser(
             "status",

--- a/seml/main.py
+++ b/seml/main.py
@@ -22,7 +22,7 @@ def main():
                         "Each experiment is represented as a record in the database. "
                         "See examples/README.md for more details.",
             formatter_class=argparse.RawTextHelpFormatter,
-            add_help=False)
+            add_help=True)
     parser.add_argument(
             'db_collection_name', type=str, nargs='?', default=None,
             help="Name of the database collection for the experiment.")
@@ -33,26 +33,22 @@ def main():
     subparsers = parser.add_subparsers(title="Possible operations")
 
     parser_jupyter = subparsers.add_parser(
-        "jupyter",
-        help="Start a Jupyter slurm job.")
+            "jupyter",
+            help="Start a Jupyter slurm job.")
     parser_jupyter.add_argument(
-        "-l", "--lab", action='store_true',
-        help="Start a jupyter-lab instance instead of jupyter notebook."
-    )
+            "-l", "--lab", action='store_true',
+            help="Start a jupyter-lab instance instead of jupyter notebook.")
     parser_jupyter.add_argument(
-        "-c", "--conda-env", type=str, default=None,
-        help="Start the Jupyter instance in a Conda environment."
-    )
-
+            "-c", "--conda-env", type=str, default=None,
+            help="Start the Jupyter instance in a Conda environment.")
     parser_jupyter.add_argument(
-        '-sb', '--sbatch-options', type=json.loads,
-        help="Dictionary (passed as a string, e.g. '{\"gres\": \"gpu:2\"}') to request two GPUs.")
-
+            '-sb', '--sbatch-options', type=json.loads,
+            help="Dictionary (passed as a string, e.g. '{\"gres\": \"gpu:2\"}') to request two GPUs.")
     parser_jupyter.set_defaults(func=start_jupyter_job)
 
     parser_configure = subparsers.add_parser(
-        "configure",
-        help="Provide your MongoDB credentials.")
+            "configure",
+            help="Provide your MongoDB credentials.")
     parser_configure.set_defaults(func=mongodb_credentials_prompt)
 
     parser_add = subparsers.add_parser(
@@ -71,13 +67,11 @@ def main():
             help="Do not check the config for missing/unused arguments. "
                  "Use this if the check fails unexpectedly when using "
                  "advanced Sacred features or to accelerate adding.")
-
     parser_add.add_argument(
-        '-ncc', '--no-code-checkpoint', action='store_true',
-        help="Do upload the source code files to the MongoDB. "
-             "When a staged experiment is started, it will use whatever is the current version of the code "
-             "files (which might have been updated in the meantime or could fail when started).")
-
+            '-ncc', '--no-code-checkpoint', action='store_true',
+            help="Do upload the source code files to the MongoDB. "
+                 "When a staged experiment is started, it will use whatever is the current version of the code "
+                 "files (which might have been updated in the meantime or could fail when started).")
     parser_add.add_argument(
             '-f', '--force-duplicates', action='store_true',
             help="Add experiments to the database even when experiments with identical configurations "
@@ -85,11 +79,10 @@ def main():
     parser_add.set_defaults(func=add_experiments)
 
     parser_start_launch_parent = argparse.ArgumentParser(add_help=False)
-
     parser_start_launch_parent.add_argument(
-        '-lss', '--local-steal-slurm', action='store_true',
-        help="Local jobs 'steal' from the Slurm queue, i.e. also execute experiments waiting for execution via Slurm."
-             "Has no effect if --local is not active.")
+            '-ss', '--steal-slurm', action='store_true',
+            help="Local jobs 'steal' from the Slurm queue, i.e. also execute experiments waiting for execution via "
+                 "Slurm. Has no effect if --local is not active.")
     parser_start_launch_parent.add_argument(
             '-n', '--num-exps', type=int, default=0,
             help="Only start the specified number of experiments. 0: run all staged experiments.")
@@ -104,40 +97,35 @@ def main():
             help="Batch ID (batch_id in the database collection) of the experiments to be started. "
                  "Experiments that were staged together have the same batch_id.")
     parser_start_launch_parent.add_argument(
-        '-f', '--filter-dict', type=json.loads,
-        help="Dictionary (passed as a string, e.g. '{\"config.dataset\": \"cora_ml\"}') to filter the experiments by.")
+            '-f', '--filter-dict', type=json.loads,
+            help="Dictionary (passed as a string, e.g. '{\"config.dataset\": \"cora_ml\"}') to filter "
+                 "the experiments by.")
     parser_start_launch_parent.add_argument(
-        '-o', '--output-to-console', action='store_true',
-        help="Print output to console.")
+            '-o', '--output-to-console', action='store_true',
+            help="Print output to console.")
     parser_start_launch_parent.add_argument(
-        '-nf', '--no-file-output', action='store_true',
-        help="Print output to console.")
+            '-nf', '--no-file-output', action='store_true',
+            help="Print output to console.")
     parser_start_launch_parent.add_argument(
-        '-wg', '--worker-gpus', type=str,
-        help="The IDs of the GPUs used by the local worker. Will be directly passed to CUDA_VISIBLE_DEVICES. Has no "
-             "effect for Slurm jobs.",
-    )
+            '-wg', '--worker-gpus', type=str,
+            help="The IDs of the GPUs used by the local worker. Will be directly passed to CUDA_VISIBLE_DEVICES. "
+                 "Has no effect for Slurm jobs.")
     parser_start_launch_parent.add_argument(
-        '-wc', '--worker-cpus', type=int,
-        help="The number of CPU cores used by the local worker. Will be directly passed to OMP_NUM_THREADS. Has no "
-             "effect for Slurm jobs.",
-    )
+            '-wc', '--worker-cpus', type=int,
+            help="The number of CPU cores used by the local worker. Will be directly passed to OMP_NUM_THREADS. Has no "
+                 "effect for Slurm jobs.")
     parser_start_launch_parent.add_argument(
-        '-we', '--worker-environment-vars', type=json.loads,
-        help="Further environment variables to be set for the local worker. Has no effect for Slurm jobs.",
-    )
-
+            '-we', '--worker-environment-vars', type=json.loads,
+            help="Further environment variables to be set for the local worker. Has no effect for Slurm jobs.")
     parser_start_launch_parent.add_argument(
-        '-u', '--unobserved', action='store_true',
-        help="Run the experiments without Sacred observers (no changes to the database). "
-             "This also disables output capturing by Sacred, facilitating the use of debuggers (pdb, ipdb).")
-
+            '-u', '--unobserved', action='store_true',
+            help="Run the experiments without Sacred observers (no changes to the database). "
+                 "This also disables output capturing by Sacred, facilitating the use of debuggers (pdb, ipdb).")
     parser_start_launch_parent.add_argument(
             '-d', '--debug', action='store_true',
             help="Run a single experiment locally without Sacred observers and with post-mortem debugging. "
                  "This is equivalent to "
                  "`--verbose --local --num-exps 1 --set_to_pending --post-mortem --output-to-console`.")
-
     parser_start_launch_parent.add_argument(
             '-dr', '--dry-run', action='store_true',
             help="Only show the associated commands instead of running the experiments.")
@@ -149,10 +137,9 @@ def main():
     parser_start.add_argument(
             '-l', '--local', action='store_true',
             help="Run the experiments locally (not via Slurm).")
-
     parser_start.add_argument(
-        '-nw', '--no-worker', action='store_true',
-        help="Do not launch a local worker after setting experiments' state to PENDING.")
+            '-nw', '--no-worker', action='store_true',
+            help="Do not launch a local worker after setting experiments' state to PENDING.")
 
     parser_start.set_defaults(func=start_experiments, set_to_pending=True)
 
@@ -237,11 +224,11 @@ def main():
     parser_detect.set_defaults(func=detect_killed)
 
     parser_clean_db = subparsers.add_parser(
-        "clean-db",
-        help="Remove orphaned artifacts in the DB from runs which have been deleted.")
+            "clean-db",
+            help="Remove orphaned artifacts in the DB from runs which have been deleted.")
     parser_clean_db.add_argument(
-        '-a', '--all-collections', action='store_true',
-        help="Scan all collections for orphaned artifacts (not just the one provided in the config).")
+            '-a', '--all-collections', action='store_true',
+            help="Scan all collections for orphaned artifacts (not just the one provided in the config).")
     parser_clean_db.set_defaults(func=clean_unreferenced_artifacts)
 
     args = parser.parse_args()

--- a/seml/main.py
+++ b/seml/main.py
@@ -123,7 +123,7 @@ def main():
              "effect for Slurm jobs.",
     )
     parser_start_launch_parent.add_argument(
-        '-wk', '--worker-kwargs', type=json.loads,
+        '-we', '--worker-environment-vars', type=json.loads,
         help="Further environment variables to be set for the local worker. Has no effect for Slurm jobs.",
     )
 

--- a/seml/main.py
+++ b/seml/main.py
@@ -129,10 +129,6 @@ def main():
             '-nw', '--no-worker', action='store_true',
             help="Do not launch a local worker after setting experiments' state to PENDING.")
     parser_start.add_argument(
-            '-u', '--unobserved', action='store_true',
-            help="Run the experiments without Sacred observers (no changes to the database). "
-                 "This also disables output capturing by Sacred, facilitating the use of debuggers (pdb, ipdb).")
-    parser_start.add_argument(
             '-d', '--debug', action='store_true',
             help="Run a single experiment locally without Sacred observers and with post-mortem debugging. "
                  "This is equivalent to "
@@ -147,7 +143,7 @@ def main():
         parents=[parser_start_launch_parent],
         help="Launch a local worker that runs PENDING jobs.")
     parser_launch_worker.set_defaults(func=start_experiments, set_to_pending=False, no_worker=False, local=True,
-                                      unobserved=False, debug=False, dry_run=False)
+                                      debug=False, dry_run=False)
 
     parser_status = subparsers.add_parser(
             "status",

--- a/seml/main.py
+++ b/seml/main.py
@@ -131,8 +131,9 @@ def main():
     parser_start.add_argument(
             '-d', '--debug', action='store_true',
             help="Run a single experiment locally without Sacred observers and with post-mortem debugging. "
-                 "This is equivalent to "
-                 "`--verbose --local --num-exps 1 --set_to_pending --post-mortem --output-to-console`.")
+                 "This is equivalent to  "
+                 "`--verbose --local --num-exps 1 --post-mortem --output-to-console`, "
+                 "and additionally we suppress Sacred observers by passing --unobserved to the experiments.")
     parser_start.add_argument(
             '-dr', '--dry-run', action='store_true',
             help="Only show the associated commands instead of running the experiments.")

--- a/seml/main.py
+++ b/seml/main.py
@@ -21,7 +21,8 @@ def main():
             description="Manage experiments for the given configuration. "
                         "Each experiment is represented as a record in the database. "
                         "See examples/README.md for more details.",
-            formatter_class=argparse.RawTextHelpFormatter)
+            formatter_class=argparse.RawTextHelpFormatter,
+            add_help=False)
     parser.add_argument(
             'db_collection_name', type=str, nargs='?', default=None,
             help="Name of the database collection for the experiment.")
@@ -83,44 +84,83 @@ def main():
                  "are already in the database.")
     parser_add.set_defaults(func=add_experiments)
 
+    parser_start_launch_parent = argparse.ArgumentParser(add_help=False)
+
+    parser_start_launch_parent.add_argument(
+        '-lss', '--local-steal-slurm', action='store_true',
+        help="Local jobs 'steal' from the Slurm queue, i.e. also execute experiments waiting for execution via Slurm."
+             "Has no effect if --local is not active.")
+    parser_start_launch_parent.add_argument(
+            '-n', '--num-exps', type=int, default=0,
+            help="Only start the specified number of experiments. 0: run all staged experiments.")
+    parser_start_launch_parent.add_argument(
+            '-pm', '--post-mortem', action='store_true',
+            help="Activate post-mortem debugging with pdb.")
+    parser_start_launch_parent.add_argument(
+            '-id', '--sacred-id', type=int,
+            help="Sacred ID (_id in the database collection) of the experiment to start.")
+    parser_start_launch_parent.add_argument(
+            '-b', '--batch-id', type=int,
+            help="Batch ID (batch_id in the database collection) of the experiments to be started. "
+                 "Experiments that were staged together have the same batch_id.")
+    parser_start_launch_parent.add_argument(
+        '-f', '--filter-dict', type=json.loads,
+        help="Dictionary (passed as a string, e.g. '{\"config.dataset\": \"cora_ml\"}') to filter the experiments by.")
+    parser_start_launch_parent.add_argument(
+        '-o', '--output-to-console', action='store_true',
+        help="Print output to console.")
+    parser_start_launch_parent.add_argument(
+        '-nf', '--no-file-output', action='store_true',
+        help="Print output to console.")
+    parser_start_launch_parent.add_argument(
+        '-wg', '--worker-gpus', type=str,
+        help="The IDs of the GPUs used by the local worker. Will be directly passed to CUDA_VISIBLE_DEVICES. Has no "
+             "effect for Slurm jobs.",
+    )
+    parser_start_launch_parent.add_argument(
+        '-wc', '--worker-cpus', type=int,
+        help="The number of CPU cores used by the local worker. Will be directly passed to OMP_NUM_THREADS. Has no "
+             "effect for Slurm jobs.",
+    )
+    parser_start_launch_parent.add_argument(
+        '-wk', '--worker-kwargs', type=json.loads,
+        help="Further environment variables to be set for the local worker. Has no effect for Slurm jobs.",
+    )
+
+    parser_start_launch_parent.add_argument(
+        '-u', '--unobserved', action='store_true',
+        help="Run the experiments without Sacred observers (no changes to the database). "
+             "This also disables output capturing by Sacred, facilitating the use of debuggers (pdb, ipdb).")
+
+    parser_start_launch_parent.add_argument(
+            '-d', '--debug', action='store_true',
+            help="Run a single experiment locally without Sacred observers and with post-mortem debugging. "
+                 "This is equivalent to "
+                 "`--verbose --local --num-exps 1 --set_to_pending --post-mortem --output-to-console`.")
+
+    parser_start_launch_parent.add_argument(
+            '-dr', '--dry-run', action='store_true',
+            help="Only show the associated commands instead of running the experiments.")
+
     parser_start = subparsers.add_parser(
             "start",
+            parents=[parser_start_launch_parent],
             help="Fetch staged experiments from the database and run them (by default via Slurm).")
     parser_start.add_argument(
             '-l', '--local', action='store_true',
             help="Run the experiments locally (not via Slurm).")
+
     parser_start.add_argument(
-            '-n', '--num-exps', type=int, default=-1,
-            help="Only start the specified number of experiments.")
-    parser_start.add_argument(
-            '-u', '--unobserved', action='store_true',
-            help="Run the experiments without Sacred observers (no changes to the database). "
-                 "This also disables output capturing by Sacred, facilitating the use of debuggers (pdb, ipdb).")
-    parser_start.add_argument(
-            '-pm', '--post-mortem', action='store_true',
-            help="Activate post-mortem debugging with pdb.")
-    parser_start.add_argument(
-            '-d', '--debug', action='store_true',
-            help="Run a single experiment locally without Sacred observers and with post-mortem debugging. "
-                 "This is equivalent to "
-                 "`--verbose --local --num-exps 1 --unobserved --post-mortem --output-to-console`.")
-    parser_start.add_argument(
-            '-dr', '--dry-run', action='store_true',
-            help="Only show the associated commands instead of running the experiments.")
-    parser_start.add_argument(
-            '-id', '--sacred-id', type=int,
-            help="Sacred ID (_id in the database collection) of the experiment to start.")
-    parser_start.add_argument(
-            '-b', '--batch-id', type=int,
-            help="Batch ID (batch_id in the database collection) of the experiments to be started. "
-                 "Experiments that were staged together have the same batch_id.")
-    parser_start.add_argument(
-        '-f', '--filter-dict', type=json.loads,
-        help="Dictionary (passed as a string, e.g. '{\"config.dataset\": \"cora_ml\"}') to filter the experiments by.")
-    parser_start.add_argument(
-        '-o', '--output-to-console', action='store_true',
-        help="Print output to console instead of writing it to a log file. Only possible if experiment is run locally.")
-    parser_start.set_defaults(func=start_experiments)
+        '-nw', '--no-worker', action='store_true',
+        help="Do not launch a local worker after setting experiments' state to PENDING.")
+
+    parser_start.set_defaults(func=start_experiments, set_to_pending=True)
+
+    parser_launch_worker = subparsers.add_parser(
+        "launch-worker",
+        parents=[parser_start_launch_parent],
+        help="Launch a local worker that runs PENDING jobs.")
+    parser_launch_worker.set_defaults(func=start_experiments, set_to_pending=False, no_worker=False, local=True)
 
     parser_status = subparsers.add_parser(
             "status",

--- a/seml/main.py
+++ b/seml/main.py
@@ -131,9 +131,7 @@ def main():
     parser_start.add_argument(
             '-d', '--debug', action='store_true',
             help="Run a single experiment locally without Sacred observers and with post-mortem debugging. "
-                 "This is equivalent to  "
-                 "`--verbose --local --num-exps 1 --post-mortem --output-to-console`, "
-                 "and additionally we suppress Sacred observers by passing --unobserved to the experiments.")
+                 "Implies `--verbose --local --num-exps 1 --post-mortem --output-to-console`.")
     parser_start.add_argument(
             '-dr', '--dry-run', action='store_true',
             help="Only show the associated commands instead of running the experiments.")

--- a/seml/prepare_experiment.py
+++ b/seml/prepare_experiment.py
@@ -31,8 +31,18 @@ if __name__ == "__main__":
 
     collection = get_collection(db_collection_name)
 
-    exp = collection.find_one({'_id': exp_id})
-    assert exp is not None
+    # this returns the document as it was BEFORE the update. So we first have to check whether its state was
+    # PENDING. Otherwise, we reset the state and abort. This is to avoid race conditions, since find_one_and_update
+    # is an atomic operation.
+    exp = collection.find_one_and_update({'_id': exp_id},
+                                         {"$set": {"status": States.RUNNING[0]}})
+    if exp is None:
+        exit(2)
+    if exp['status'] not in States.PENDING:
+        # reset state to the previous state before we updated it to RUNNING.
+        exp = collection.find_one_and_update({'_id': exp_id},
+                                             {"$set": {"status": exp['status']}})
+        exit(1)
     use_stored_sources = args.stored_sources_dir is not None
     if use_stored_sources and not os.listdir(args.stored_sources_dir):
         assert "source_files" in exp['seml'],\
@@ -57,10 +67,5 @@ if __name__ == "__main__":
                 {'_id': exp_id},
                 {'$set': {'seml.command': cmd}})
 
-    if exp is None:
-        exit(2)
-    if exp['status'] not in States.PENDING:
-        exit(1)
-    else:
-        print(cmd)
-        exit(0)
+    print(cmd)
+    exit(0)

--- a/seml/start.py
+++ b/seml/start.py
@@ -592,14 +592,6 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
     output_to_file = not no_file_output
     launch_worker = not no_worker
 
-    if filter_dict is None:
-        filter_dict = {}
-
-    if use_slurm and not set_to_pending:
-        logging.error("use_slurm is True but set_to_pending is False, which are incompatible. Either perform local"
-                      "processing and set set_to_pending to False, or have set_to_pending=True and use_slurm=True.")
-        return
-
     if debug:
         num_exps = 1
         use_slurm = False
@@ -607,6 +599,14 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
         post_mortem = True
         output_to_file = False
         logging.root.setLevel(logging.VERBOSE)
+
+    if filter_dict is None:
+        filter_dict = {}
+
+    if use_slurm and not set_to_pending:
+        logging.error("use_slurm is True but set_to_pending is False, which are incompatible. Either perform local"
+                      "processing and set set_to_pending to False, or have set_to_pending=True and use_slurm=True.")
+        return
 
     if unobserved:
         set_to_pending = False

--- a/seml/start.py
+++ b/seml/start.py
@@ -584,7 +584,7 @@ def print_commands(collection, unobserved, post_mortem, num_exps, filter_dict):
 
 
 def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dict,
-                      num_exps, unobserved, post_mortem, debug, dry_run,
+                      num_exps, post_mortem, debug, dry_run,
                       output_to_console, no_file_output, steal_slurm,
                       no_worker, set_to_pending=True, worker_gpus=None, worker_cpus=None, worker_environment_vars=None):
 
@@ -592,6 +592,7 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
     output_to_file = not no_file_output
     launch_worker = not no_worker
 
+    unobserved = False
     if debug:
         num_exps = 1
         use_slurm = False

--- a/seml/start.py
+++ b/seml/start.py
@@ -137,7 +137,10 @@ def start_slurm_job(collection, exp_array, unobserved=False, post_mortem=False, 
     if 'output' in sbatch_options:
         logging.error(f"Can't set sbatch `output` Parameter explicitly. SEML will do that for you.")
         sys.exit(1)
-    sbatch_options['output'] = f'{output_dir_path}/{name}_%A_%a.out'
+    elif output_dir_path != "/dev/null":
+        sbatch_options['output'] = f'{output_dir_path}/{name}_%A_%a.out'
+    else:
+        sbatch_options['output'] = output_dir_path
 
     # Construct sbatch options string
     sbatch_options_str = create_sbatch_options_string(sbatch_options)
@@ -197,7 +200,8 @@ def start_slurm_job(collection, exp_array, unobserved=False, post_mortem=False, 
     os.remove(path)
 
 
-def start_local_job(collection, exp, unobserved=False, post_mortem=False, output_dir_path='.'):
+def start_local_job(collection, exp, unobserved=False, post_mortem=False,
+                    output_dir_path='.', output_to_console=False):
     """Run an experiment locally.
 
     Parameters
@@ -212,10 +216,13 @@ def start_local_job(collection, exp, unobserved=False, post_mortem=False, output
         Activate post-mortem debugging.
     output_dir_path: str
         Write the output to a file in `output_dir` given by the SEML config or in the current directory.
+    output_to_console:
+        Pipe all output (stdout and stderr) to the console.
 
     Returns
     -------
-    None
+    True if job was executed successfully; False if it failed; None if job was not started because the database entry
+    was not in the PENDING state.
     """
 
     use_stored_sources = ('source_files' in exp['seml'])
@@ -227,18 +234,6 @@ def start_local_job(collection, exp, unobserved=False, post_mortem=False, output
         os.chdir(exp['seml']['working_dir'])
 
     cmd = f"python {exe} with {' '.join(config)}"
-    if not unobserved:
-        # check also whether PENDING experiments have their Slurm ID set, in this case they are waiting
-        # for Slurm execution and we don't start them locally.
-        db_entry = collection.find_one_and_update(filter={'_id': exp['_id'], 'status': {"$in": States.PENDING},
-                                                          'slurm.array_id': {'$exists': False}},
-                                                  update={'$set': {'seml.command': cmd,
-                                                                   'status': States.RUNNING[0]}},
-                                                  upsert=False)
-        if db_entry is None:
-            # another worker already set this entry to PENDING (or at least, it's no longer STAGED)
-            # so we ignore it.
-            return None
 
     success = True
     try:
@@ -256,6 +251,15 @@ def start_local_job(collection, exp, unobserved=False, post_mortem=False, output
             # update the command to use the temp dir
             cmd = f'PYTHONPATH="{temp_dir}:$PYTHONPATH" python {temp_dir}/{exe} with {" ".join(config)}'
 
+        if output_dir_path:
+            exp_name = get_exp_name(exp, collection.name)
+            output_file = f"{output_dir_path}/{exp_name}_{exp['_id']}.out"
+            collection.find_one_and_update({'_id': exp['_id']}, {"$set": {"seml.output_file": output_file}})
+            if output_to_console:
+                # redirect output to logfile AND output to console. See https://stackoverflow.com/a/34604684.
+                # Alternatively, we could go with subprocess.Popen, but this could conflict with pdb.
+                cmd = f"{cmd} 2>&1 | tee -a {output_file}"
+
         if 'conda_environment' in seml_config and seml_config['conda_environment'] is not None:
             cmd = (f". $(conda info --base)/etc/profile.d/conda.sh "
                    f"&& conda activate {seml_config['conda_environment']} "
@@ -265,12 +269,12 @@ def start_local_job(collection, exp, unobserved=False, post_mortem=False, output
         logging.verbose(f'Running the following command:\n {cmd}')
 
         if output_dir_path:
-            exp_name = get_exp_name(exp, collection.name)
-            output_file = f"{output_dir_path}/{exp_name}_{exp['_id']}.out"
-            collection.find_and_modify({'_id': exp['_id']}, {"$set": {"seml.output_file": output_file}})
-            with open(output_file, "w") as log_file:
-                # pdb works with check_call but not with check_output. Maybe because of stdout/stdin.
-                subprocess.check_call(cmd, shell=True, stderr=log_file, stdout=log_file)
+            if output_to_console:
+                subprocess.check_call(cmd, shell=True,)
+            else:  # redirect output to logfile
+                with open(output_file, "w") as log_file:
+                    # pdb works with check_call but not with check_output. Maybe because of stdout/stdin.
+                    subprocess.check_call(cmd, shell=True, stderr=log_file, stdout=log_file)
         else:
             subprocess.check_call(cmd, shell=True)
 
@@ -283,12 +287,11 @@ def start_local_job(collection, exp, unobserved=False, post_mortem=False, output
                                        update={'$set': {'status': States.FAILED[0]}},
                                        upsert=False)
         success = False
-
     finally:
         if use_stored_sources and 'temp_dir' in locals():
             # clean up temp directory
             shutil.rmtree(temp_dir)
-        return success
+    return success
 
 
 def chunk_list(exps):
@@ -338,124 +341,218 @@ def batch_chunks(exp_chunks):
     return exp_arrays
 
 
-def start_jobs(db_collection_name, slurm=True, unobserved=False,
-               post_mortem=False, num_exps=-1, filter_dict=None, dry_run=False,
-               output_to_file=True):
-    """Pull staged experiments from the database and run them.
+def get_staged_experiments(collection, filter_dict=None, num_exps=0, slurm=True, set_to_pending=True):
+    """
+    Load experiments with state STAGED from the input MongoDB collection. If set_to_pending is True, we also set their
+    status to PENDING.
 
     Parameters
     ----------
-    db_collection_name: str
-        Name of the collection in the MongoDB.
+    collection: pymongo.collection.Collection
+        The MongoDB collection with STAGED experiments.
+    filter_dict: dict
+        Optional dict with custom database filters.
+    num_exps: int
+        Only set <num_exps> experiments' state to PENDING. If 0, set all STAGED experiments to PENDING.
     slurm: bool
-        Use the Slurm cluster.
+        If True, we also set 'slurm.array_id' in order to prevent these jobs from being executed by local workers.
+    set_to_pending: bool
+        Whether to update the database entries to status PENDING.
+
+    Returns
+    -------
+    The list of database entries with status STAGED.
+    """
+    if filter_dict is None:
+        filter_dict = {}
+
+    query_dict = {'status': {"$in": States.STAGED}}
+    query_dict.update(filter_dict)
+
+    staged_experiments = list(collection.find(query_dict, limit=num_exps))
+    if set_to_pending:
+        update_dict = {"$set": {"status": States.PENDING[0]}}
+        if slurm:
+            # set slurm.array_id so that local workers don't start these jobs.
+            update_dict['$set']['slurm.array_id'] = None
+
+        if num_exps > 0:
+            # only set the experiments to PENDING which will be run.
+            collection.update_many({'_id': {'$in': [e['_id'] for e in staged_experiments
+                                                    if e['status'] in States.STAGED]}},
+                                   update_dict, )
+        else:
+            collection.update_many(query_dict, update_dict)
+
+    return staged_experiments
+
+
+def set_environment_variables(gpus=None, cpus=None, environment_variables=None):
+    if environment_variables is None:
+        environment_variables = {}
+
+    if gpus is not None:
+        if isinstance(gpus, list):
+            logging.info('Received an input of type list to set CUDA_VISIBLE_DEVICES.'
+                         'Please pass a string for input "gpus", e.g. "1,2" if you want to use GPUs with IDs 1 and 2.')
+            exit(1)
+        environment_variables['CUDA_VISIBLE_DEVICES'] = str(gpus)
+    if cpus is not None:
+        environment_variables['OMP_NUM_THREADS'] = str(cpus)
+    os.environ.update(environment_variables)
+
+
+def add_to_slurm_queue(collection, exps_list, unobserved=False, post_mortem=False,
+                       output_to_file=True, output_to_console=False):
+    """
+    Send the input list of experiments to the Slurm system for execution.
+
+    Parameters
+    ----------
+    collection: pymongo.collection.Collection
+        The MongoDB collection containing the experiments.
+    exps_list: list of dicts
+        The list of database entries corresponding to experiments to be executed.
     unobserved: bool
-        Disable all Sacred observers (nothing written to MongoDB).
+        Whether to suppress observation by Sacred observers.
     post_mortem: bool
         Activate post-mortem debugging.
-    num_exps: int, default: -1
-        If >0, will only submit the specified number of experiments to the cluster.
-        This is useful when you only want to test your setup.
-    filter_dict: dict
-        Dictionary for filtering the entries in the collection.
-    dry_run: bool
-        Just return the executables and configurations instead of running them.
     output_to_file: bool
-        Pipe all output (stdout and stderr) to an output file.
-        Can only be False if slurm is False.
+        Whether to capture output in a logfile.
+    output_to_console: bool
+        Whether to capture output in the console. This is currently not supported for Slurm jobs and will raise an
+        error if set to True.
 
     Returns
     -------
     None
     """
-    if filter_dict is None:
-        filter_dict = {}
 
-    collection = get_collection(db_collection_name)
+    if output_to_console:
+        logging.error("Output cannot be written to stdout in Slurm mode. "
+                      "Remove the '--output-to-console' argument.")
+        sys.exit(1)
+    nexps = len(exps_list)
+    exp_chunks = chunk_list(exps_list)
+    exp_arrays = batch_chunks(exp_chunks)
+    njobs = len(exp_chunks)
+    narrays = len(exp_arrays)
 
-    if unobserved and not slurm and '_id' in filter_dict:
-        query_dict = {}
-    elif not slurm:
-        query_dict = {'status': {"$in": [*States.STAGED, *States.PENDING]}, 'slurm.array_id': {'$exists': False}}
-    else:
-        query_dict = {'status': {"$in": States.STAGED}}
-    query_dict.update(filter_dict)
+    logging.info(f"Starting {nexps} experiment{s_if(nexps)} in "
+                 f"{njobs} Slurm job{s_if(njobs)} in {narrays} Slurm job array{s_if(narrays)}.")
 
-    if collection.count_documents(query_dict) <= 0:
-        logging.error("No staged experiments.")
-        return
-
-    exps_full = list(collection.find(query_dict))
-
-    nexps = num_exps if num_exps > 0 else len(exps_full)
-    exps_list = exps_full[:nexps]
-
-    if dry_run:
-        configs = []
-        for exp in exps_list:
-            exe, config = get_command_from_exp(exp, db_collection_name,
-                                               verbose=logging.root.level <= logging.VERBOSE,
-                                               unobserved=unobserved, post_mortem=post_mortem)
-            if 'conda_environment' in exp['seml']:
-                configs.append((exe, exp['seml']['conda_environment'], config))
-            else:
-                configs.append((exe, None, config))
-        return configs
-    elif slurm:
-        if not output_to_file:
-            logging.error("Output cannot be written to stdout in Slurm mode. "
-                          "Remove the '--output-to-console' argument.")
-            sys.exit(1)
-        exp_chunks = chunk_list(exps_list)
-        exp_arrays = batch_chunks(exp_chunks)
-        njobs = len(exp_chunks)
-        narrays = len(exp_arrays)
-
-        logging.info(f"Starting {nexps} experiment{s_if(nexps)} in "
-                     f"{njobs} Slurm job{s_if(njobs)} in {narrays} Slurm job array{s_if(narrays)}.")
-
-        for exp_array in exp_arrays:
-            job_name = get_exp_name(exp_array[0][0], collection.name)
+    for exp_array in exp_arrays:
+        job_name = get_exp_name(exp_array[0][0], collection.name)
+        if output_to_file:
             output_dir_path = get_output_dir_path(exp_array[0][0])
-            slurm_config = exp_array[0][0]['slurm']
-            del slurm_config['experiments_per_job']
-            start_slurm_job(collection, exp_array, unobserved, post_mortem,
-                            name=job_name, output_dir_path=output_dir_path, **slurm_config)
-    else:
-        login_node_name = 'fs'
-        if login_node_name in os.uname()[1]:
-            logging.error("Refusing to run a compute experiment on a login node. "
-                          "Please use Slurm or a compute node.")
-            sys.exit(1)
-        # [get_output_dir_path(exp) for exp in exps_list]  # Check if output dir exists
-        logging.info(f'Starting local worker thread that will run up to {nexps} experiment{s_if(nexps)}, '
+        else:
+            output_dir_path = "/dev/null"
+        slurm_config = exp_array[0][0]['slurm']
+        del slurm_config['experiments_per_job']
+        start_slurm_job(collection, exp_array, unobserved, post_mortem,
+                        name=job_name, output_dir_path=output_dir_path,
+                        **slurm_config)
+
+
+def start_local_worker(collection, num_exps=0, filter_dict=None, unobserved=False, post_mortem=False,
+                       local_steal_slurm_jobs=False, output_to_console=False, output_to_file=True,
+                       gpus=None, cpus=None, environment_variables=None):
+    """
+    Start a local worker on the current machine that pulls PENDING experiments from the database and executes them.
+
+    Parameters
+    ----------
+    collection: pymongo.collection.Collection
+        The MongoDB collection containing the experiments.
+    num_exps: int
+        The maximum number of experiments run by this worker before terminating.
+    filter_dict: dict
+        Optional dict with custom database filters.
+    unobserved: bool
+        Whether to suppress observation by Sacred observers.
+    post_mortem: bool
+        Activate post-mortem debugging.
+    local_steal_slurm_jobs: bool
+        If True, the local worker will also execute jobs waiting for execution in Slurm.
+    output_to_console: bool
+        Whether to capture output in the console.
+    output_to_file: bool
+        Whether to capture output in a logfile.
+    gpus: str
+        Comma-separated list of GPU IDs to be used by this worker (e.g., "2,3"). Will be passed to CUDA_VISIBLE_DEVICES.
+    cpus: int
+        Number of CPU cores to be used by this worker. If None, use all cores.
+    environment_variables: dict
+        Optional dict of additional environment variables to be set.
+
+    Returns
+    -------
+    None
+    """
+    login_node_name = 'fs'
+    if login_node_name in os.uname()[1]:
+        logging.error("Refusing to run a compute experiment on a login node. "
+                      "Please use Slurm or a compute node.")
+        sys.exit(1)
+
+    if num_exps > 0:
+        logging.info(f'Starting local worker thread that will run up to {num_exps} experiment{s_if(num_exps)}, '
                      f'until no staged experiments remain.')
-        if not unobserved:
-            collection.update_many({'_id': {'$in': [e['_id'] for e in exps_list if e['status'] in States.STAGED]}},
-                                   {"$set": {"status": States.PENDING[0]}})
-        num_exceptions = 0
-        tq = tqdm(enumerate(exps_list))
-        for i_exp, exp in tq:
-            if output_to_file:
-                output_dir_path = get_output_dir_path(exp)
-            else:
-                output_dir_path = None
-            success = start_local_job(collection, exp, unobserved, post_mortem, output_dir_path)
+    else:
+        logging.info(f'Starting local worker thread that will run experiments until no staged experiments remain.')
+        num_exps = int(1e30)
+
+    set_environment_variables(gpus, cpus, environment_variables)
+
+    num_exceptions = 0
+    jobs_counter = 0
+
+    if not local_steal_slurm_jobs:
+        staged_query = {'status': {"$in": States.PENDING}, 'slurm.array_id': {'$exists': False}}
+    else:
+        staged_query = {'status': {"$in": States.PENDING}}
+
+    staged_query.update(filter_dict)
+
+    tq = tqdm()
+    while collection.count_documents(staged_query) > 0 and jobs_counter < num_exps:
+        exp = collection.find_one_and_update(staged_query, {"$set": {"status": States.RUNNING[0]}})
+        if exp['status'] not in States.PENDING:
+            # reset to its old state.
+            collection.find_one_and_update({'_id': exp['_id']}, {"$set": {"status": exp['status']}})
+            continue
+
+        if output_to_file:
+            output_dir_path = get_output_dir_path(exp)
+        else:
+            output_dir_path = None
+        try:
+            success = start_local_job(collection=collection, exp=exp, unobserved=unobserved, post_mortem=post_mortem,
+                                      output_dir_path=output_dir_path, output_to_console=output_to_console)
             if success is False:
                 num_exceptions += 1
-            tq.set_postfix(failed=f"{num_exceptions}/{i_exp} experiments")
+        except KeyboardInterrupt:
+            logging.info("Caught KeyboardInterrupt signal. Aborting.")
+            exit(1)
+        jobs_counter += 1
+        tq.set_postfix(failed=f"{num_exceptions}/{jobs_counter} experiments")
 
 
-def print_commands(db_collection_name, unobserved, post_mortem, num_exps, filter_dict):
+def print_commands(collection, unobserved, post_mortem, num_exps, filter_dict):
     orig_level = logging.root.level
     logging.root.setLevel(logging.VERBOSE)
-    configs = start_jobs(db_collection_name, slurm=False,
-                         unobserved=True, post_mortem=False,
-                         num_exps=1, filter_dict=filter_dict, dry_run=True)
-    if configs is None:
+    exps_list = get_staged_experiments(collection=collection, filter_dict=filter_dict, num_exps=num_exps,
+                                       set_to_pending=False)
+    if len(exps_list) == 0:
         return
+
+    exp = exps_list[0]
+    exe, config = get_command_from_exp(exp, collection.name,
+                                       verbose=logging.root.level <= logging.VERBOSE,
+                                       unobserved=unobserved, post_mortem=False)
+    env = exp['seml']['conda_environment'] if 'conda_environment' in exp['seml'] else None
+
     logging.info("********** First experiment **********")
-    exe, env, config = configs[0]
     logging.info(f"Executable: {exe}")
     if env is not None:
         logging.info(f"Anaconda environment: {env}")
@@ -472,26 +569,44 @@ def print_commands(db_collection_name, unobserved, post_mortem, num_exps, filter
     logging.info(" ".join(config))
 
     logging.info("\nCommand for running locally with post-mortem debugging:")
-    configs = start_jobs(db_collection_name, slurm=False,
-                         unobserved=True, post_mortem=True,
-                         num_exps=1, filter_dict=filter_dict, dry_run=True)
-    exe, _, config = configs[0]
+    exe, config = get_command_from_exp(exps_list[0], collection.name,
+                                       verbose=logging.root.level <= logging.VERBOSE,
+                                       unobserved=unobserved, post_mortem=True)
     logging.info(f"python {exe} with {' '.join(config)}")
 
     logging.info("\n********** All raw commands **********")
     logging.root.setLevel(orig_level)
-    configs = start_jobs(db_collection_name, slurm=False,
-                         unobserved=unobserved, post_mortem=post_mortem,
-                         num_exps=num_exps, filter_dict=filter_dict, dry_run=True)
-    for (exe, _, config) in configs:
+    start_experiments(collection, local=True,
+                      unobserved=unobserved, post_mortem=post_mortem,
+                      num_exps=num_exps, filter_dict=filter_dict, dry_run=True)
+    for exp in exps_list:
+        exe, config = get_command_from_exp(exp, collection.name,
+                                           unobserved=unobserved, post_mortem=post_mortem)
         logging.info(f"python {exe} with {' '.join(config)}")
 
 
 def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dict,
                       num_exps, unobserved, post_mortem, debug, dry_run,
-                      output_to_console):
+                      output_to_console, no_file_output, local_steal_slurm,
+                      no_worker, set_to_pending=True, worker_gpus=None, worker_cpus=None, worker_kwargs=None):
+
     use_slurm = not local
-    output_to_file = not output_to_console
+    output_to_file = not no_file_output
+    launch_worker = not no_worker
+
+    if filter_dict is None:
+        filter_dict = {}
+
+    if use_slurm and not set_to_pending:
+        logging.error("use_slurm is True but set_to_pending is False, which are incompatible. Either perform local"
+                      "processing and set set_to_pending to False, or have set_to_pending=True and use_slurm=True.")
+        return
+
+    if unobserved:
+        set_to_pending = False
+
+    if worker_kwargs is None:
+        worker_kwargs = {}
 
     if debug:
         num_exps = 1
@@ -504,16 +619,34 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
     if sacred_id is None:
         filter_dict = build_filter_dict([], batch_id, filter_dict)
     else:
-        filter_dict = {'_id': sacred_id}
+        # if we have a specific sacred ID, we ignore the state of the experiment and run it in any case.
+        all_states = (States.PENDING + States.STAGED + States.RUNNING + States.FAILED + States.INTERRUPTED
+                      + States.KILLED + States.COMPLETED)
+        filter_dict.update({'_id': sacred_id, "status": {"$in": all_states}})
+
+    collection = get_collection(db_collection_name)
 
     if dry_run:
-        print_commands(db_collection_name, unobserved=unobserved, post_mortem=post_mortem,
+        print_commands(collection, unobserved=unobserved, post_mortem=post_mortem,
                        num_exps=num_exps, filter_dict=filter_dict)
-    else:
-        start_jobs(db_collection_name, slurm=use_slurm,
-                   unobserved=unobserved, post_mortem=post_mortem,
-                   num_exps=num_exps, filter_dict=filter_dict, dry_run=dry_run,
-                   output_to_file=output_to_file)
+        return
+
+    staged_experiments = get_staged_experiments(collection=collection, filter_dict=filter_dict, num_exps=num_exps,
+                                                slurm=use_slurm, set_to_pending=set_to_pending)
+
+    if len(staged_experiments) == 0 and use_slurm:
+        logging.error("No staged experiments.")
+        return
+
+    if use_slurm:
+        add_to_slurm_queue(collection=collection, exps_list=staged_experiments, unobserved=unobserved,
+                           post_mortem=post_mortem, output_to_file=output_to_file, output_to_console=output_to_console)
+
+    elif launch_worker:
+        start_local_worker(collection=collection, num_exps=num_exps, filter_dict=filter_dict, unobserved=unobserved,
+                           post_mortem=post_mortem, local_steal_slurm_jobs=local_steal_slurm,
+                           output_to_console=output_to_console, output_to_file=output_to_file,
+                           gpus=worker_gpus, cpus=worker_cpus, **worker_kwargs)
 
 
 def start_jupyter_job(sbatch_options: dict = None, conda_env: str = None, lab: bool = False):

--- a/seml/start.py
+++ b/seml/start.py
@@ -588,7 +588,7 @@ def print_commands(collection, unobserved, post_mortem, num_exps, filter_dict):
 def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dict,
                       num_exps, unobserved, post_mortem, debug, dry_run,
                       output_to_console, no_file_output, local_steal_slurm,
-                      no_worker, set_to_pending=True, worker_gpus=None, worker_cpus=None, worker_kwargs=None):
+                      no_worker, set_to_pending=True, worker_gpus=None, worker_cpus=None, worker_environment_vars=None):
 
     use_slurm = not local
     output_to_file = not no_file_output
@@ -646,7 +646,7 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
         start_local_worker(collection=collection, num_exps=num_exps, filter_dict=filter_dict, unobserved=unobserved,
                            post_mortem=post_mortem, local_steal_slurm_jobs=local_steal_slurm,
                            output_to_console=output_to_console, output_to_file=output_to_file,
-                           gpus=worker_gpus, cpus=worker_cpus, **worker_kwargs)
+                           gpus=worker_gpus, cpus=worker_cpus, environment_variables=worker_environment_vars)
 
 
 def start_jupyter_job(sbatch_options: dict = None, conda_env: str = None, lab: bool = False):

--- a/seml/start.py
+++ b/seml/start.py
@@ -604,11 +604,6 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
     if filter_dict is None:
         filter_dict = {}
 
-    if use_slurm and not set_to_pending:
-        logging.error("use_slurm is True but set_to_pending is False, which are incompatible. Either perform local"
-                      "processing and set set_to_pending to False, or have set_to_pending=True and use_slurm=True.")
-        return
-
     if unobserved:
         set_to_pending = False
 

--- a/seml/start.py
+++ b/seml/start.py
@@ -600,12 +600,6 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
                       "processing and set set_to_pending to False, or have set_to_pending=True and use_slurm=True.")
         return
 
-    if unobserved:
-        set_to_pending = False
-
-    if worker_environment_vars is None:
-        worker_environment_vars = {}
-
     if debug:
         num_exps = 1
         use_slurm = False
@@ -613,6 +607,12 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
         post_mortem = True
         output_to_file = False
         logging.root.setLevel(logging.VERBOSE)
+
+    if unobserved:
+        set_to_pending = False
+
+    if worker_environment_vars is None:
+        worker_environment_vars = {}
 
     if sacred_id is None:
         filter_dict = build_filter_dict([], batch_id, filter_dict)


### PR DESCRIPTION
### Reference issue
Backlog :-)


### What does this implement/fix?
Major overhaul to local workers and refactoring to `start.py`. Major changes:

* added command `launch-worker` to `main.py`. This can be used to spawn additional local workers.
* added option `--local-steal-slurm` to local jobs. This enables hybrid processing where local workers pop experiments from the Slurm queue. Since we check the database state before actually running the experiment via Slurm, there is no risk of duplicate computation.
* added options `--worker-gpus`,  `--worker-cpus`, and `--worker-environment-vars` to customize local workers.
* Added section on local mode to README.md
