### PR TITLE
Slurm debug

### DIFF
--- a/seml/database.py
+++ b/seml/database.py
@@ -254,33 +254,3 @@ def clean_unreferenced_artifacts(db_collection_name, all_collections=False):
     for to_delete in tqdm(not_referenced_artifacts):
         fs.delete(to_delete)
     logging.info(f'Successfully deleted {n_delete} not referenced artifact{s_if(n_delete)}.')
-
-
-def find_one_and_update(collection, unobserved, *pymongo_args, **pymongo_kwargs):
-    """
-    Run find_one_and_update only if unobserved is False
-    Parameters
-    ----------
-    collection: Collection
-        Database collection to be scanned
-    unobserved: bool
-        Whether to change the collection
-    pymongo_args: list
-        Arguments passed to find_one_and_update
-    pymongo_kwargs: dict
-        Arguments passed to find_one_and_update
-
-    Returns
-    -------
-    list[dict]: Found MongoDB entries
-    """
-
-    if unobserved:
-        if len(pymongo_args) >= 2:
-            pymongo_args = list(pymongo_args)
-            del pymongo_args[1]
-        if 'update' in pymongo_kwargs:
-            del pymongo_kwargs['update']
-        return collection.find_one(*pymongo_args, **pymongo_kwargs)
-    else:
-        return collection.find_one_and_update(*pymongo_args, **pymongo_kwargs)

--- a/seml/database.py
+++ b/seml/database.py
@@ -254,3 +254,33 @@ def clean_unreferenced_artifacts(db_collection_name, all_collections=False):
     for to_delete in tqdm(not_referenced_artifacts):
         fs.delete(to_delete)
     logging.info(f'Successfully deleted {n_delete} not referenced artifact{s_if(n_delete)}.')
+
+
+def find_one_and_update(collection, unobserved, *pymongo_args, **pymongo_kwargs):
+    """
+    Run find_one_and_update only if unobserved is False
+    Parameters
+    ----------
+    collection: Collection
+        Database collection to be scanned
+    unobserved: bool
+        Whether to change the collection
+    pymongo_args: list
+        Arguments passed to find_one_and_update
+    pymongo_kwargs: dict
+        Arguments passed to find_one_and_update
+
+    Returns
+    -------
+    list[dict]: Found MongoDB entries
+    """
+
+    if unobserved:
+        if len(pymongo_args) >= 2:
+            pymongo_args = list(pymongo_args)
+            del pymongo_args[1]
+        if 'update' in pymongo_kwargs:
+            del pymongo_kwargs['update']
+        return collection.find_one(*pymongo_args, **pymongo_kwargs)
+    else:
+        return collection.find_one_and_update(*pymongo_args, **pymongo_kwargs)

--- a/seml/jupyter_template.sh
+++ b/seml/jupyter_template.sh
@@ -2,7 +2,7 @@
 {sbatch_options}
 
 # Move either to project root dir or the config file path.
-cd {working_dir}
+cd ${{SLURM_SUBMIT_DIR}}
 
 # Print job information
 echo "Starting job ${{SLURM_JOBID}}"

--- a/seml/main.py
+++ b/seml/main.py
@@ -69,8 +69,8 @@ def main():
                  "advanced Sacred features or to accelerate adding.")
     parser_add.add_argument(
             '-ncc', '--no-code-checkpoint', action='store_true',
-            help="Do upload the source code files to the MongoDB. "
-                 "When a staged experiment is started, it will use whatever is the current version of the code "
+            help="Do not save the source code files in the MongoDB. "
+                 "When a staged experiment is started, it will instead use the current version of the code "
                  "files (which might have been updated in the meantime or could fail when started).")
     parser_add.add_argument(
             '-f', '--force-duplicates', action='store_true',
@@ -164,8 +164,8 @@ def main():
 
     parser_reset = subparsers.add_parser(
             "reset",
-            help="Reset the state of experiments (set to STAGED and clean database entry) "
-                 "by ID or state (does not cancel Slurm jobs).")
+            help="Reset the state of experiments by setting their state to staged and cleaning their database entry. "
+                 "Does not cancel Slurm jobs.")
     parser_reset.add_argument(
             '-s', '--filter-states', type=str, nargs='*', default=[*States.FAILED, *States.KILLED,
                                                                    *States.INTERRUPTED],

--- a/seml/main.py
+++ b/seml/main.py
@@ -133,7 +133,7 @@ def main():
             help="Run a single experiment without Sacred observers and with post-mortem debugging. "
                  "Implies `--verbose --num-exps 1 --post-mortem --output-to-console`.")
     parser_start.add_argument(
-            '-dr', '--dry-run', action='store_true',
+            '-pc', '--print-command', action='store_true',
             help="Only show the associated commands instead of running the experiments.")
     parser_start.set_defaults(func=start_experiments, set_to_pending=True)
 
@@ -142,7 +142,7 @@ def main():
         parents=[parser_start_launch_parent],
         help="Launch a local worker that runs PENDING jobs.")
     parser_launch_worker.set_defaults(func=start_experiments, set_to_pending=False, no_worker=False, local=True,
-                                      debug=False, dry_run=False)
+                                      debug=False, print_command=False)
 
     parser_status = subparsers.add_parser(
             "status",

--- a/seml/main.py
+++ b/seml/main.py
@@ -130,8 +130,8 @@ def main():
             help="Do not launch a local worker after setting experiments' state to PENDING.")
     parser_start.add_argument(
             '-d', '--debug', action='store_true',
-            help="Run a single experiment locally without Sacred observers and with post-mortem debugging. "
-                 "Implies `--verbose --local --num-exps 1 --post-mortem --output-to-console`.")
+            help="Run a single experiment without Sacred observers and with post-mortem debugging. "
+                 "Implies `--verbose --num-exps 1 --post-mortem --output-to-console`.")
     parser_start.add_argument(
             '-dr', '--dry-run', action='store_true',
             help="Only show the associated commands instead of running the experiments.")

--- a/seml/main.py
+++ b/seml/main.py
@@ -92,9 +92,6 @@ def main():
             '-ds', '--debug-server', action='store_true',
             help="Run the experiment with a debug server, to which you can remotely connect with e.g. VS Code. "
                  "Implies `--debug`.")
-    parser_start.add_argument(
-            '-nf', '--no-file-output', action='store_true',
-            help="Do not save the console output in a file.")
     parser_start_local = parser_start.add_argument_group("optional arguments for local jobs")
     parser_start_local.add_argument(
             '-l', '--local', action='store_true',
@@ -117,6 +114,9 @@ def main():
         subparser.add_argument(
                 '-pm', '--post-mortem', action='store_true',
                 help="Activate post-mortem debugging with pdb.")
+        subparser.add_argument(
+                '-nf', '--no-file-output', action='store_true',
+                help="Do not save the console output in a file.")
 
     for subparser in [parser_start_local, parser_launch_worker]:
         subparser.add_argument(

--- a/seml/main.py
+++ b/seml/main.py
@@ -86,7 +86,7 @@ def main():
             help="Only show the associated commands instead of running the experiments.")
     parser_start.add_argument(
             '-d', '--debug', action='store_true',
-            help="Run a single experiment without Sacred observers and with post-mortem debugging. "
+            help="Run a single interactive experiment without Sacred observers and with post-mortem debugging. "
                  "Implies `--verbose --num-exps 1 --post-mortem --output-to-console`.")
     parser_start.add_argument(
             '-ds', '--debug-server', action='store_true',
@@ -112,9 +112,6 @@ def main():
                 '-n', '--num-exps', type=int, default=0,
                 help="Only start the specified number of experiments. 0: run all staged experiments.")
         subparser.add_argument(
-                '-pm', '--post-mortem', action='store_true',
-                help="Activate post-mortem debugging with pdb.")
-        subparser.add_argument(
                 '-nf', '--no-file-output', action='store_true',
                 help="Do not save the console output in a file.")
 
@@ -134,6 +131,9 @@ def main():
         subparser.add_argument(
                 '-we', '--worker-environment-vars', type=json.loads,
                 help="Further environment variables to be set for the local worker. Has no effect for Slurm jobs.")
+        subparser.add_argument(
+                '-pm', '--post-mortem', action='store_true',
+                help="Activate post-mortem debugging with pdb.")
         subparser.add_argument(
                 '-o', '--output-to-console', action='store_true',
                 help="Print output to console.")

--- a/seml/main.py
+++ b/seml/main.py
@@ -133,6 +133,10 @@ def main():
             help="Run a single experiment without Sacred observers and with post-mortem debugging. "
                  "Implies `--verbose --num-exps 1 --post-mortem --output-to-console`.")
     parser_start.add_argument(
+            '-ds', '--debug-server', action='store_true',
+            help="Run the experiment with a debug server, to which you can remotely connect with e.g. VS Code. "
+                 "Implies `--debug`.")
+    parser_start.add_argument(
             '-pc', '--print-command', action='store_true',
             help="Only show the associated commands instead of running the experiments.")
     parser_start.set_defaults(func=start_experiments, set_to_pending=True)
@@ -142,7 +146,7 @@ def main():
         parents=[parser_start_launch_parent],
         help="Launch a local worker that runs PENDING jobs.")
     parser_launch_worker.set_defaults(func=start_experiments, set_to_pending=False, no_worker=False, local=True,
-                                      debug=False, print_command=False)
+                                      debug=False, debug_server=False, print_command=False)
 
     parser_status = subparsers.add_parser(
             "status",

--- a/seml/network.py
+++ b/seml/network.py
@@ -1,0 +1,47 @@
+import socket
+from contextlib import closing
+import fcntl
+import struct
+import array
+import sys
+
+
+def get_network_interfaces():
+    # From https://code.activestate.com/recipes/439093/#c1
+    is_64bits = sys.maxsize > 2**32
+    struct_size = 40 if is_64bits else 32
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    max_possible = 8 # initial value
+    while True:
+        _bytes = max_possible * struct_size
+        names = array.array('B')
+        for i in range(0, _bytes):
+            names.append(0)
+        outbytes = struct.unpack('iL', fcntl.ioctl(
+            s.fileno(),
+            0x8912,  # SIOCGIFCONF
+            struct.pack('iL', _bytes, names.buffer_info()[0])
+        ))[0]
+        if outbytes == _bytes:
+            max_possible *= 2
+        else:
+            break
+    namestr = names.tostring()
+    ifaces = {}
+    for i in range(0, outbytes, struct_size):
+        iface_name = bytes.decode(namestr[i:i+16]).split('\0', 1)[0]
+        iface_addr = socket.inet_ntoa(namestr[i+20:i+24])
+        ifaces[iface_name] = iface_addr
+
+    return ifaces
+
+
+def find_free_port():
+    ifaces = get_network_interfaces()
+    if 'lo' in ifaces:
+        del ifaces['lo']
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind((list(ifaces.values())[0], 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        ip_address, port = s.getsockname()[:2]
+        return ip_address, port

--- a/seml/prepare_experiment.py
+++ b/seml/prepare_experiment.py
@@ -54,8 +54,7 @@ if __name__ == "__main__":
                               find_dict, {"$set": {"status": States.RUNNING[0]}})
     if exp is None:
         # check whether experiment is actually missing from the DB or has the wrong state
-        exp = collection.find_one({'_id': exp_id})
-        if exp is None:
+        if collection.count_documents({'_id': exp_id}) == 0:
             exit(2)
         else:
             exit(1)

--- a/seml/slurm_template.sh
+++ b/seml/slurm_template.sh
@@ -47,11 +47,7 @@ for exp_id in "${{exp_ids[@]}}"; do
 
     ret=$?
     if [ $ret -eq 0 ]; then
-        if {parallel_processing}; then
-            eval $cmd &
-        else
-            eval $cmd
-        fi
+        eval $cmd &
         process_ids+=($!)
     elif [ $ret -eq 1 ]; then
         echo "WARNING: Experiment with ID ${{exp_id}} does not have status PENDING and will not be run."

--- a/seml/slurm_template.sh
+++ b/seml/slurm_template.sh
@@ -47,7 +47,11 @@ for exp_id in "${{exp_ids[@]}}"; do
 
     ret=$?
     if [ $ret -eq 0 ]; then
-        eval $cmd &
+        if {parallel_processing}; then
+            eval $cmd &
+        else
+            eval $cmd
+        fi
         process_ids+=($!)
     elif [ $ret -eq 1 ]; then
         echo "WARNING: Experiment with ID ${{exp_id}} does not have status PENDING and will not be run."

--- a/seml/slurm_template.sh
+++ b/seml/slurm_template.sh
@@ -43,7 +43,7 @@ fi
 # Start experiments in separate processes
 process_ids=()
 for exp_id in "${{exp_ids[@]}}"; do
-    cmd=$(python -c '{prepare_experiment_script}' --experiment_id ${{exp_id}} --db_collection_name {db_collection_name} {sources_argument} --verbose {verbose} --unobserved {unobserved} --post-mortem {post_mortem})
+    cmd=$(python -c '{prepare_experiment_script}' --experiment_id ${{exp_id}} --db_collection_name {db_collection_name} {sources_argument} --verbose {verbose} --unobserved {unobserved} --post-mortem {post_mortem} --debug-server {debug_server})
 
     ret=$?
     if [ $ret -eq 0 ]; then

--- a/seml/slurm_template.sh
+++ b/seml/slurm_template.sh
@@ -43,7 +43,7 @@ fi
 # Start experiments in separate processes
 process_ids=()
 for exp_id in "${{exp_ids[@]}}"; do
-    cmd=$(python -c '{prepare_experiment_script}' --experiment_id ${{exp_id}} --db_collection_name {db_collection_name} {sources_argument} --verbose {verbose} --unobserved {unobserved} --post-mortem {post_mortem} --debug-server {debug_server})
+    cmd=$(python -c '{prepare_experiment_script}' --experiment_id ${{exp_id}} --db_collection_name {db_collection_name} {sources_argument} --verbose {verbose} --unobserved {unobserved} --debug-server {debug_server})
 
     ret=$?
     if [ $ret -eq 0 ]; then

--- a/seml/start.py
+++ b/seml/start.py
@@ -612,6 +612,11 @@ def start_local_worker(collection, num_exps=0, filter_dict=None, unobserved=Fals
 
     tq = tqdm()
     while collection.count_documents(staged_query) > 0 and jobs_counter < num_exps:
+
+        # Add newline if we need to avoid tqdm's output
+        if debug_server or output_to_console or logging.root.level <= logging.VERBOSE:
+            print(file=sys.stderr)
+
         if unobserved:
             exp = collection.find_one(staged_query)
         else:

--- a/seml/start.py
+++ b/seml/start.py
@@ -42,7 +42,7 @@ def get_command_from_exp(exp, db_collection_name, verbose=False, unobserved=Fals
 
     if debug_server:
         ip_address, port = find_free_port()
-        logging.info(f"Starting debug server with IP {ip_address} and port {port}.")
+        logging.info(f"Starting debug server with IP {ip_address} and port {port}. Experiment will wait for a debug client to attach.")
         interpreter = f"python -m debugpy --listen {ip_address}:{port} --wait-for-client"
     else:
         interpreter = "python"

--- a/seml/start.py
+++ b/seml/start.py
@@ -756,10 +756,6 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
                                                     slurm=use_slurm, set_to_pending=set_to_pending)
 
     if use_slurm:
-        if len(staged_experiments) == 0:
-            logging.error("No staged experiments.")
-            return
-
         add_to_slurm_queue(collection=collection, exps_list=staged_experiments, unobserved=unobserved,
                            post_mortem=post_mortem, output_to_file=output_to_file,
                            output_to_console=output_to_console, srun=srun,

--- a/seml/start.py
+++ b/seml/start.py
@@ -593,6 +593,12 @@ def start_local_worker(collection, num_exps=0, filter_dict=None, unobserved=Fals
                       "Please use Slurm or a compute node.")
         sys.exit(1)
 
+    if 'SLURM_JOBID' in os.environ:
+        node_str = subprocess.run("squeue -j ${SLURM_JOBID} -O nodelist:1000",
+                                  shell=True, check=True, capture_output=True).stdout
+        node_id = node_str.decode("utf-8").split('\n')[1].strip()
+        logging.info(f"SLURM assigned me the node(s): {node_id}")
+
     if num_exps > 0:
         logging.info(f'Starting local worker thread that will run up to {num_exps} experiment{s_if(num_exps)}, '
                      f'or until no pending experiments remain.')

--- a/seml/start.py
+++ b/seml/start.py
@@ -655,7 +655,6 @@ def start_jupyter_job(sbatch_options: dict = None, conda_env: str = None, lab: b
 
     script = template.format(
             sbatch_options=sbatch_options_str,
-            working_dir="${SLURM_SUBMIT_DIR}",
             use_conda_env=str(conda_env is not None).lower(),
             conda_env=conda_env,
             notebook_or_lab=" notebook" if lab is False else "-lab",

--- a/seml/start.py
+++ b/seml/start.py
@@ -611,7 +611,7 @@ def print_commands(collection, unobserved, post_mortem, num_exps, filter_dict):
     logging.root.setLevel(orig_level)
     start_experiments(collection, local=True,
                       unobserved=unobserved, post_mortem=post_mortem,
-                      num_exps=num_exps, filter_dict=filter_dict, dry_run=True)
+                      num_exps=num_exps, filter_dict=filter_dict, print_command=True)
     for exp in exps_list:
         exe, config = get_command_from_exp(exp, collection.name,
                                            unobserved=unobserved, post_mortem=post_mortem)
@@ -619,7 +619,7 @@ def print_commands(collection, unobserved, post_mortem, num_exps, filter_dict):
 
 
 def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dict,
-                      num_exps, post_mortem, debug, dry_run,
+                      num_exps, post_mortem, debug, print_command,
                       output_to_console, no_file_output, steal_slurm,
                       no_worker, set_to_pending=True, worker_gpus=None, worker_cpus=None, worker_environment_vars=None):
 
@@ -655,7 +655,7 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
 
     collection = get_collection(db_collection_name)
 
-    if dry_run:
+    if print_command:
         print_commands(collection, unobserved=unobserved, post_mortem=post_mortem,
                        num_exps=num_exps, filter_dict=filter_dict)
         return

--- a/seml/start.py
+++ b/seml/start.py
@@ -473,8 +473,8 @@ def add_to_slurm_queue(collection, exps_list, unobserved=False, post_mortem=Fals
     """
 
     if output_to_console and not srun:
-        logging.error("Output cannot be written to stdout in Slurm mode. "
-                      "Remove the '--output-to-console' argument.")
+        logging.error("Output cannot be written to stdout in regular Slurm mode. "
+                      "Remove the '--output-to-console' argument or use '--debug'.")
         sys.exit(1)
     nexps = len(exps_list)
     exp_chunks = chunk_list(exps_list)
@@ -642,12 +642,9 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
     use_slurm = not local
     output_to_file = not no_file_output
     launch_worker = not no_worker
-
-    if debug_server:
-        debug = True
-
     unobserved = False
-    if debug:
+
+    if debug or debug_server:
         num_exps = 1
         unobserved = True
         post_mortem = True

--- a/seml/start.py
+++ b/seml/start.py
@@ -388,7 +388,7 @@ def batch_chunks(exp_chunks):
     return exp_arrays
 
 
-def get_staged_experiments(collection, filter_dict=None, num_exps=0, slurm=True, set_to_pending=True):
+def prepare_staged_experiments(collection, filter_dict=None, num_exps=0, slurm=True, set_to_pending=True):
     """
     Load experiments with state STAGED from the input MongoDB collection. If set_to_pending is True, we also set their
     status to PENDING.
@@ -595,8 +595,8 @@ def start_local_worker(collection, num_exps=0, filter_dict=None, unobserved=Fals
 def print_commands(collection, unobserved, post_mortem, debug_server, num_exps, filter_dict):
     orig_level = logging.root.level
     logging.root.setLevel(logging.VERBOSE)
-    exps_list = get_staged_experiments(collection=collection, filter_dict=filter_dict, num_exps=num_exps,
-                                       set_to_pending=False)
+    exps_list = prepare_staged_experiments(collection=collection, filter_dict=filter_dict, num_exps=num_exps,
+                                           set_to_pending=False)
     if len(exps_list) == 0:
         return
 
@@ -702,8 +702,8 @@ def start_experiments(db_collection_name, local, sacred_id, batch_id, filter_dic
                        num_exps=num_exps, filter_dict=filter_dict)
         return
 
-    staged_experiments = get_staged_experiments(collection=collection, filter_dict=filter_dict, num_exps=num_exps,
-                                                slurm=use_slurm, set_to_pending=set_to_pending)
+    staged_experiments = prepare_staged_experiments(collection=collection, filter_dict=filter_dict, num_exps=num_exps,
+                                                    slurm=use_slurm, set_to_pending=set_to_pending)
 
     if use_slurm:
         if len(staged_experiments) == 0:

--- a/seml/start.py
+++ b/seml/start.py
@@ -638,6 +638,7 @@ def start_local_worker(collection, num_exps=0, filter_dict=None, unobserved=Fals
             logging.info("Caught KeyboardInterrupt signal. Aborting.")
             exit(1)
         jobs_counter += 1
+        tq.update()
         tq.set_postfix(failed=f"{num_exceptions}/{jobs_counter} experiments")
 
 

--- a/seml/start.py
+++ b/seml/start.py
@@ -307,6 +307,13 @@ def start_local_job(collection, exp, unobserved=False, post_mortem=False,
                    f"&& {cmd} "
                    f"&& conda deactivate")
 
+        if 'SLURM_JOBID' in os.environ and not unobserved:
+            collection.update_one(
+                    {'_id': exp['_id']},
+                    {'$set': {
+                        'slurm.array_id': os.environ['SLURM_JOBID'],
+                        'slurm.task_id': 0}})
+
         logging.verbose(f'Running the following command:\n {cmd}')
 
         if output_dir_path:

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ install_requires = [
     "jsonpickle>=1.2, <2.0",
     "munch>=2.0.4",
     "tqdm>=4.36",
+    "debugpy>=1.2.1"
 ]
 
 with open("README.md", "r") as fh:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,15 +68,15 @@ class TestParseConfigDicts(unittest.TestCase):
 
     def test_duplicate_parameters(self):
         config_dict = self.load_config_dict(self.CONFIG_WITH_DUPLICATE_PARAMETERS_1)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(SystemExit):
             configs = config.generate_configs(config_dict)
 
         config_dict = self.load_config_dict(self.CONFIG_WITH_DUPLICATE_PARAMETERS_2)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(SystemExit):
             configs = config.generate_configs(config_dict)
 
         config_dict = self.load_config_dict(self.CONFIG_WITH_DUPLICATE_PARAMETERS_3)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(SystemExit):
             configs = config.generate_configs(config_dict)
 
 


### PR DESCRIPTION
### What does this implement/fix?
New debugging capabilities:
- Debugging now works on Slurm! We do this by starting an interactive job via `srun`, in which we use the regular local `seml` command.
- New `debug-server` option, which spawns a debug server via [debugpy](https://github.com/microsoft/debugpy), which an IDE (e.g. VS Code) can attach to remotely. This way we get both the convenience of SEML and a full IDE! Unfortunately, PyCharm's remote debugging [doesn't offer a workflow that would work with SEML](https://www.jetbrains.com/help/pycharm/remote-debugging-with-product.html) and is therefore incompatible with this.
- Fixed some bugs with debugging, which were introduced when overhauling local workers


### Additional information
- Renamed `--dry-run` to `--print-command`
- Changed `subprocess.check_X` to `subprocess.run`, as officially recommended
- Improved some parameter errors by exiting instead of printing a stack trace
- Some other minor changes
