### PR TITLE
New YamlLoader that disallows duplicate keys

### DIFF
--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -71,7 +71,6 @@ fixed:
   max_epochs: 500
 
 grid:
-
   learning_rate:
     type: loguniform
     min: 1e-5

--- a/seml/config.py
+++ b/seml/config.py
@@ -189,7 +189,7 @@ def generate_configs(experiment_config):
 
         if len(redefined_parameters) > 0:
             logging.warning(f"Found redefined parameters in {current_sub_name}: {redefined_parameters}. "
-                            f"Redefinitions of parameters override earlier ones.")
+                            f"Definitions in sub-configs override higher (more general) ones.")
             config_above = copy.deepcopy(config_above)
             for p in redefined_parameters:
                 sections = inverted_config_above[p]

--- a/seml/start.py
+++ b/seml/start.py
@@ -617,7 +617,8 @@ def start_local_worker(collection, num_exps=0, filter_dict=None, unobserved=Fals
     if not unobserved:
         exp_query['status'] = {"$in": States.PENDING}
     if not steal_slurm:
-        exp_query['$and'] = [{'slurm.array_id': {'$exists': False}}, {'slurm.id': {'$exists': False}}]
+        exp_query['slurm.array_id'] = {'$exists': False}
+        exp_query['slurm.id'] = {'$exists': False}
 
     exp_query.update(filter_dict)
 

--- a/tests/resources/config/config_with_duplicate_parameters_3.yaml
+++ b/tests/resources/config/config_with_duplicate_parameters_3.yaml
@@ -1,0 +1,3 @@
+fixed:
+  a: ccc
+  a: ddd

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,8 @@ class TestParseConfigDicts(unittest.TestCase):
     SIMPLE_CONFIG_WITH_PARAMETER_COLLECTIONS_RANDOM = "resources/config/config_with_parameter_collections_random.yaml"
     CONFIG_WITH_DUPLICATE_PARAMETERS_1 = "resources/config/config_with_duplicate_parameters_1.yaml"
     CONFIG_WITH_DUPLICATE_PARAMETERS_2 = "resources/config/config_with_duplicate_parameters_2.yaml"
-    CONFIG_WITH_DUPLICATE_PARAMETERS_3 = "resources/config/config_nested_parameter_collections.yaml"
+    CONFIG_WITH_DUPLICATE_PARAMETERS_3 = "resources/config/config_with_duplicate_parameters_3.yaml"
+    CONFIG_WITH_DUPLICATE_PARAMETERS_NESTED = "resources/config/config_nested_parameter_collections.yaml"
     CONFIG_WITH_DUPLICATE_RDM_PARAMETERS_2 = "resources/config/config_with_duplicate_random_parameters_1.yaml"
     CONFIG_WITH_ALL_TYPES = "resources/config/config_with_all_types.yaml"
 
@@ -75,10 +76,12 @@ class TestParseConfigDicts(unittest.TestCase):
         with self.assertRaises(SystemExit):
             configs = config.generate_configs(config_dict)
 
-        config_dict = self.load_config_dict(self.CONFIG_WITH_DUPLICATE_PARAMETERS_3)
+        with self.assertRaises(SystemExit):
+            configs = config.read_config(self.CONFIG_WITH_DUPLICATE_PARAMETERS_3)
+
+        config_dict = self.load_config_dict(self.CONFIG_WITH_DUPLICATE_PARAMETERS_NESTED)
         with self.assertRaises(SystemExit):
             configs = config.generate_configs(config_dict)
-
 
         config_dict = self.load_config_dict(self.CONFIG_WITH_DUPLICATE_RDM_PARAMETERS_2)
         configs = config.generate_configs(config_dict)


### PR DESCRIPTION
### What does this implement/fix?
Users defining the same parameter twice without realizing it.


### Additional information
This disallows _all_ duplicate keys. Users can no longer define 2 `fixed` blocks or 2 `grid` blocks on the same level, or abuse the overriding behavior. This doesn't seem restrictive and is imho actually good practise. But it will inevitably break some users' configs.

Users can still redefine a parameter in a sub-config, in which case the precedence should be clear.
