### PR TITLE
Fix Issue 47

### DIFF
--- a/seml/manage.py
+++ b/seml/manage.py
@@ -297,7 +297,7 @@ def get_slurm_arrays_tasks():
         squeue_out = subprocess.run(
                 f"SLURM_BITSTR_LEN=256 squeue -a -t {','.join(SETTINGS.SLURM_STATES.ACTIVE)} -h -o %i -u `whoami`",
                 shell=True, check=True, capture_output=True).stdout
-        jobs = [job_str for job_str in squeue_out.splitlines() if b'_' in job_str]
+        jobs = [job_str for job_str in squeue_out.splitlines() if b'_' in job_str b'%' not in job_str]
         if len(jobs) > 0:
             array_ids_str, task_ids = zip(*[job_str.split(b'_') for job_str in jobs])
             job_dict = {}


### PR DESCRIPTION
<!-- 
This PR fixes Issue #47 by checking for '%' in SLURM job array string which should not be present in SLURM job arrays created by seml
-->

### Reference issue
<!--Example: Closes #47 -->


### What does this implement/fix?
<!--Please explain your changes.-->
This PR fixes Issue #47 by checking for '%' in SLURM job array string which should not be present in SLURM job arrays created by seml

### Additional information
This works under the assumption, that SEML does not use throttled job arrays
