### PR TITLE
Use `repr` instead of `json.dumps`

### DIFF
--- a/seml/network.py
+++ b/seml/network.py
@@ -26,7 +26,7 @@ def get_network_interfaces():
             max_possible *= 2
         else:
             break
-    namestr = names.tostring()
+    namestr = names.tobytes()
     ifaces = {}
     for i in range(0, outbytes, struct_size):
         iface_name = bytes.decode(namestr[i:i+16]).split('\0', 1)[0]

--- a/seml/start.py
+++ b/seml/start.py
@@ -36,11 +36,10 @@ def get_command_from_exp(exp, db_collection_name, verbose=False, unobserved=Fals
     if not unobserved:
         config['overwrite'] = exp['_id']
 
-    # We encode the values as JSON because it can also be evaluated as python literals and
-    # it requires strings in double quotes while calling `repr` on the values would use
-    # single quotes. Single quotes would later on lead to messy commands when the values
-    # are escaped with `shlex.quote`.
-    config_strings = [f"{key}={json.dumps(val)}" for key, val in config.items()]
+    # We encode values with `repr` such that we can decode them with `eval`. While `shlex.quote`
+    # may cause messy commands with lots of single quotes JSON doesn't match Python 1:1, e.g.,
+    # boolean values are lower case in JSON (true, false) but start with capital letters in Python.
+    config_strings = [f"{key}={repr(val)}" for key, val in config.items()]
 
     if not verbose:
         config_strings.append("--force")


### PR DESCRIPTION
### Reference issue
This is a follow-up PR to #51.
#51 uses `json.dumps` which works reasonably fine in most scenarios and avoids a long range of single quotes in the outputted commands. However, JSON and Python code is not a 1:1 matching, e.g., boolean literals start with lower case in JSON (true/false) but with upper case in Python (True/False). This causes any parameter containing a boolean value to be returned as string by `eval`.
<!--Example: Closes gh-WXYZ.-->


### What does this implement/fix?
This PR contains two fixes:
* It replaces `json.dumps` by `repr` to have a valid Python representation of the object
* It replaces `names.tostring()` which got removed in Python 3.9 by `names.tobytes()` in `network.py` (this is simply a maintenance update without any functional impact)


### Additional information
```YAML
seml:
  executable: script.py
  name: test
  output_dir: ~/slurm-output
  conda_environment: seml_test
  project_root_dir: .

slurm:
  experiments_per_job: 1
  sbatch_options:
    gres: gpu:0
    mem: 1G
    cpus-per-task: 1
    time: 00-00:01
    partition: cpu
    qos: cpu


fixed:
  wfnet.test: True
```
```python
import seml
from sacred import Experiment

ex = Experiment()
seml.setup_logger(ex)

@ex.config
def config():
    overwrite = None
    db_collection = None
    
    if db_collection is not None:
        ex.observers.append(seml.create_mongodb_observer(
            db_collection, overwrite=overwrite))

@ex.automain
def run(
    wfnet: dict,
    seed=None,
):
    return locals()
```
`seml print-command`
```
********** First experiment **********
Executable: script.py
Anaconda environment: seml_test

Arguments for VS Code debugger:
["with", "--debug", "wfnet={'test': True}", "config_hash='69ca8ced44256974e296284455dbabc6'", "db_collection='seml_test'", "--unobserved"]
Arguments for PyCharm debugger:
with --debug 'wfnet={'"'"'test'"'"': True}' 'config_hash='"'"'69ca8ced44256974e296284455dbabc6'"'"'' 'db_collection='"'"'seml_test'"'"'' --unobserved

Command for post-mortem debugging:
python script.py with 'wfnet={'"'"'test'"'"': True}' 'config_hash='"'"'69ca8ced44256974e296284455dbabc6'"'"'' 'db_collection='"'"'seml_test'"'"'' --unobserved --pdb

Command for remote debugging:
python -m debugpy --listen 172.24.64.17:35557 --wait-for-client script.py with 'wfnet={'"'"'test'"'"': True}' 'config_hash='"'"'69ca8ced44256974e296284455dbabc6'"'"'' 'db_collection='"'"'seml_test'"'"'' --unobserved

********** All raw commands **********
python script.py with 'wfnet={'"'"'test'"'"': True}' 'config_hash='"'"'69ca8ced44256974e296284455dbabc6'"'"'' 'db_collection='"'"'seml_test'"'"'' overwrite=19 --force
```

While the commands are certainly not beautiful they are at least correct.