### PR TITLE
add settings to always confirm cancelling

### DIFF
--- a/seml/manage.py
+++ b/seml/manage.py
@@ -116,7 +116,7 @@ def cancel_experiments(db_collection_name, sacred_id, filter_states, batch_id, f
             filter_dict = build_filter_dict(filter_states, batch_id, filter_dict)
 
             ncancel = collection.count_documents(filter_dict)
-            if ncancel >= 10 or (ncancel > 0 and SETTINGS.ALWAYS_CONFIRM_CANCEL):
+            if ncancel >= SETTINGS.CONFIRM_CANCEL_THRESHOLD:
                 if input(f"Cancelling {ncancel} experiment{s_if(ncancel)}. "
                          f"Are you sure? (y/n) ").lower() != "y":
                     exit()
@@ -157,7 +157,7 @@ def cancel_experiments(db_collection_name, sacred_id, filter_states, batch_id, f
             logging.warning(f"One or multiple Slurm jobs were no longer running when I tried to cancel them.")
     else:
         logging.info(f"Cancelling experiment with ID {sacred_id}.")
-        if SETTINGS.ALWAYS_CONFIRM_CANCEL:
+        if SETTINGS.CONFIRM_CANCEL_THRESHOLD <= 1:
             if input('Are you sure? (y/n)').lower() != 'y':
                 exit()
         cancel_experiment_by_id(collection, sacred_id)

--- a/seml/manage.py
+++ b/seml/manage.py
@@ -116,7 +116,7 @@ def cancel_experiments(db_collection_name, sacred_id, filter_states, batch_id, f
             filter_dict = build_filter_dict(filter_states, batch_id, filter_dict)
 
             ncancel = collection.count_documents(filter_dict)
-            if ncancel >= 10:
+            if ncancel >= 10 or (ncancel > 0 and SETTINGS.ALWAYS_CONFIRM_CANCEL):
                 if input(f"Cancelling {ncancel} experiment{s_if(ncancel)}. "
                          f"Are you sure? (y/n) ").lower() != "y":
                     exit()
@@ -157,6 +157,9 @@ def cancel_experiments(db_collection_name, sacred_id, filter_states, batch_id, f
             logging.warning(f"One or multiple Slurm jobs were no longer running when I tried to cancel them.")
     else:
         logging.info(f"Cancelling experiment with ID {sacred_id}.")
+        if SETTINGS.ALWAYS_CONFIRM_CANCEL:
+            if input('Are you sure? (y/n)').lower() != 'y':
+                exit()
         cancel_experiment_by_id(collection, sacred_id)
 
 

--- a/seml/settings.py
+++ b/seml/settings.py
@@ -81,7 +81,7 @@ SETTINGS = munchify(
             }
         },
 
-        "ALWAYS_CONFIRM_CANCEL": False,
+        "CONFIRM_CANCEL_THRESHOLD": 10,
     },
 )
 

--- a/seml/settings.py
+++ b/seml/settings.py
@@ -80,6 +80,8 @@ SETTINGS = munchify(
                 "DEFAULT_CHANNEL": "YOUR_DEFAULT_CHANNEL",
             }
         },
+
+        "ALWAYS_CONFIRM_CANCEL": False,
     },
 )
 


### PR DESCRIPTION
### What does this implement/fix?
It happens to me occasionally that I want to cancel some experiments but missed something in the filter dict causing the cancellation of many experiments. Seml only asks if more than 10 experiments are cancelled while this is a reasonable heuristic if one has few but long-running jobs cancelling 5 may already be unfortunate.

This adds an option that is disabled by default that causes seml to always asks for confirmation before cancelling any job. It can be overwritten in the user settings.
<!--Please explain your changes.-->