### PR TITLE
use json when printing vs code commands

### DIFF
--- a/seml/start.py
+++ b/seml/start.py
@@ -30,6 +30,7 @@ def value_to_str(value, use_json=False):
     if use_json:
         result = json.dumps(value)
 
+        # Source: https://stackoverflow.com/a/6249375
         reg_str = r'"(?:[^"\\\\]*|\\\\["\\\\bfnrt\/]|\\\\u[0-9a-f]{4})*"'
         reg_num = r'-?(?=[1-9]|0(?!\d))\d+(?:\.\d+)?(?:[eE][+-]?\d+)?'
         reg_bool = r'true|false|null|True|False|None'


### PR DESCRIPTION
Fixes #65.

This implements an alternative path to convert values to strings to deal with https://github.com/microsoft/vscode/issues/91578. We manually replace `false`, `true` and `null` by `False`, `True` and `None` via regex.

The example from #65 prints:
```
********** First experiment **********
Executable: script.py
Anaconda environment: seml_test

Arguments for VS Code debugger:
["with", "--debug", "nicholas1={\"a\": \"test\"}", "marten=\"marten's data with \\\"quotes\\\" in quotes\"", "nicholas2=True", "johannes={\"dataset\": \"test\"}", "db_collection=\"seml_demo\"", "--unobserved"]
Arguments for PyCharm debugger:
with --debug 'nicholas1={'"'"'a'"'"': '"'"'test'"'"'}' 'marten='"'"'marten\'"'"'s data with "quotes" in quotes'"'"'' nicholas2=True 'johannes={'"'"'dataset'"'"': '"'"'test'"'"'}' 'db_collection='"'"'seml_demo'"'"'' --unobserved

Command for post-mortem debugging:
python script.py with 'nicholas1={'"'"'a'"'"': '"'"'test'"'"'}' 'marten='"'"'marten\'"'"'s data with "quotes" in quotes'"'"'' nicholas2=True 'johannes={'"'"'dataset'"'"': '"'"'test'"'"'}' 'db_collection='"'"'seml_demo'"'"'' --unobserved --pdb

Command for remote debugging:
python -m debugpy --listen 172.24.64.17:44261 --wait-for-client script.py with 'nicholas1={'"'"'a'"'"': '"'"'test'"'"'}' 'marten='"'"'marten\'"'"'s data with "quotes" in quotes'"'"'' nicholas2=True 'johannes={'"'"'dataset'"'"': '"'"'test'"'"'}' 'db_collection='"'"'seml_demo'"'"'' --unobserved

********** All raw commands **********
python script.py with 'nicholas1={'"'"'a'"'"': '"'"'test'"'"'}' 'marten='"'"'marten\'"'"'s data with "quotes" in quotes'"'"'' nicholas2=True 'johannes={'"'"'dataset'"'"': '"'"'test'"'"'}' 'db_collection='"'"'seml_demo'"'"'' overwrite=1 --force
```

Remark: This seems super inefficient and horrendously slow if someone has a better idea please make this faster!