### PR TITLE
Raise descriptive config error if sbatch fails

### DIFF
--- a/seml/start.py
+++ b/seml/start.py
@@ -228,7 +228,10 @@ def start_sbatch_job(collection, exp_array, unobserved=False, name=None,
     with open(path, "w") as f:
         f.write(script)
 
-    output = subprocess.run(f'sbatch {path}', shell=True, check=True, capture_output=True).stdout
+    try:
+        output = subprocess.run(f'sbatch {path}', shell=True, check=True, capture_output=True).stdout
+    except subprocess.CalledProcessError as e:
+        raise ConfigError(e.stderr.decode('utf-8'))
 
     slurm_array_job_id = int(output.split(b' ')[-1])
     for task_id, chunk in enumerate(exp_array):

--- a/seml/start.py
+++ b/seml/start.py
@@ -231,6 +231,7 @@ def start_sbatch_job(collection, exp_array, unobserved=False, name=None,
     try:
         output = subprocess.run(f'sbatch {path}', shell=True, check=True, capture_output=True).stdout
     except subprocess.CalledProcessError as e:
+        os.remove(path)
         raise ConfigError(e.stderr.decode('utf-8'))
 
     slurm_array_job_id = int(output.split(b' ')[-1])
@@ -837,7 +838,11 @@ def start_jupyter_job(sbatch_options: dict = None, conda_env: str = None, lab: b
     with open(path, "w") as f:
         f.write(script)
 
-    output = subprocess.run(f'sbatch {path}', shell=True, check=True, capture_output=True).stdout
+    try:
+        output = subprocess.run(f'sbatch {path}', shell=True, check=True, capture_output=True).stdout
+    except subprocess.CalledProcessError as e:
+        os.remove(path)
+        raise ConfigError(e.stderr.decode('utf-8'))
     os.remove(path)
 
     slurm_array_job_id = int(output.split(b' ')[-1])


### PR DESCRIPTION
At the moment, if `sbatch` fails because one specifies wrong `sbatch` parameters `seml` fails with something like the following:
```
Starting 40 experiments in 40 Slurm jobs in 2 Slurm job arrays.
Traceback (most recent call last):
  File "/nfs/homedirs/wollschl/anaconda3/envs/localized-smoothing-cuda11/bin/seml", line 8, in <module>
    sys.exit(main())
  File "/nfs/homedirs/wollschl/anaconda3/envs/localized-smoothing-cuda11/lib/python3.7/site-packages/seml/main.py", line 231, in main
    f(**args.__dict__)
  File "/nfs/homedirs/wollschl/anaconda3/envs/localized-smoothing-cuda11/lib/python3.7/site-packages/seml/start.py", line 784, in start_experiments
    debug_server=debug_server)
  File "/nfs/homedirs/wollschl/anaconda3/envs/localized-smoothing-cuda11/lib/python3.7/site-packages/seml/start.py", line 542, in add_to_slurm_queue
    debug_server=debug_server)
  File "/nfs/homedirs/wollschl/anaconda3/envs/localized-smoothing-cuda11/lib/python3.7/site-packages/seml/start.py", line 202, in start_sbatch_job
    output = subprocess.run(f'sbatch {path}', shell=True, check=True, capture_output=True).stdout
  File "/nfs/homedirs/wollschl/anaconda3/envs/localized-smoothing-cuda11/lib/python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command 'sbatch /tmp/202409.sh' returned non-zero exit status 1.
```
This is quite undescriptive on what went wrong.
To get the actual error one would have to do `sbatch /tmp/202409.sh` which would returns something like
```
sbatch: error: Invalid --mem specification
```

## Changes
This PR instead assumes that if something went wrong with `sbatch` it is due to a faulty sbatch config, thus, we raise a `ConfigError` with the `sbatch` `stderr`.
An error now looks something like this:
```
Starting 6 experiments in 6 Slurm jobs in 1 Slurm job array.
CONFIG ERROR: sbatch: error: invalid memory constraint 16n_
```
for the `yaml` file:
```yaml
...

slurm:
  experiments_per_job: 1
  sbatch_options:
    gres: gpu:1 
    mem: 16n_ G          # typo here
    cpus-per-task: 2
    time: 0-08:00

...
```