### PR TITLE
Fix neptune api token argument, fixes #91

### DIFF
--- a/seml/observers.py
+++ b/seml/observers.py
@@ -156,6 +156,9 @@ def create_neptune_observer(project_name, api_token=None,
         if "OBSERVERS" in SETTINGS and "NEPTUNE" in SETTINGS.OBSERVERS:
             if "AUTH_TOKEN" in SETTINGS.OBSERVERS.NEPTUNE:
                 api_token = SETTINGS.OBSERVERS.NEPTUNE.AUTH_TOKEN
+                # Ignore example token setting
+                if api_token == "YOUR_AUTH_TOKEN":
+                    api_token = None
 
     if api_token is None:
         logging.info('No API token for Neptune provided. Trying to use environment variable NEPTUNE_API_TOKEN.')

--- a/seml/observers.py
+++ b/seml/observers.py
@@ -156,10 +156,9 @@ def create_neptune_observer(project_name, api_token=None,
         if "OBSERVERS" in SETTINGS and "NEPTUNE" in SETTINGS.OBSERVERS:
             if "AUTH_TOKEN" in SETTINGS.OBSERVERS.NEPTUNE:
                 api_token = SETTINGS.OBSERVERS.NEPTUNE.AUTH_TOKEN
-    else:
-        api_token = SETTINGS.OBSERVERS.NEPTUNE.AUTH_TOKEN
+
     if api_token is None:
-        logging.info('No API token for Nepune provided. Trying to use environment variable NEPTUNE_API_TOKEN.')
+        logging.info('No API token for Neptune provided. Trying to use environment variable NEPTUNE_API_TOKEN.')
     neptune_obs = NeptuneObserver(api_token=api_token, project_name=project_name, source_extensions=source_extensions)
     return neptune_obs
 


### PR DESCRIPTION
<!-- 
Thank you for contributing a pull request!
Please name and describe your PR as you would write a
commit message.
-->

### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #91 

### What does this implement/fix?
<!--Please explain your changes.-->
The fix changes how the API token is set depending on the function argument. And should fix issue #91.

### Additional information
<!--Any additional information you think is important.-->
The PR also implements, that the example setting for the token in the settings.py is ignored. Otherwise the Neptune API token will never be read from the environment.
