### PR TITLE
Random config: reverse if-statements

### DIFF
--- a/seml/parameters.py
+++ b/seml/parameters.py
@@ -76,10 +76,10 @@ def sample_parameter(parameter, samples, seed=None, parent_key=''):
         raise ConfigError(f"No type found in parameter {parameter}")
     return_items = []
     allowed_keys = ['seed', 'type']
-    if seed is not None:
-        np.random.seed(seed)
-    elif 'seed' in parameter:
+    if 'seed' in parameter:
         np.random.seed(parameter['seed'])
+    elif seed is not None:
+        np.random.seed(seed)
 
     param_type = parameter['type']
 


### PR DESCRIPTION
### Reference issue
Given the following config:
```
random:
  samples: 5
  seed: 42
  a:
    type: uniform
    min: 0
    max: 1
    seed: 43

  b:
    type: uniform
    min: 0
    max: 1
    seed: 44
```
The outer seed overwrites the inner seeds.

### What does this implement/fix?
Reversing the if-statements [1] solves the problem.

[1] https://github.com/TUM-DAML/seml/blob/master/seml/parameters.py#L79

### Additional information
Not sure if you really want to reset the outer seed for every parameter. Just setting the outer seed once should be sufficient. But seems like this requires a larger fix, since the inner seeds then overwrite the outer seed again.
