### PR TITLE
Evaluate project_root_dir relative to config_dir

### DIFF
--- a/seml/config.py
+++ b/seml/config.py
@@ -418,7 +418,8 @@ def determine_executable_and_working_dir(config_path, seml_dict):
         executable_relative_to_config = os.path.exists(executable)
     executable_relative_to_project_root = False
     if 'project_root_dir' in seml_dict:
-        working_dir = str(Path(seml_dict['project_root_dir']).expanduser().resolve())
+        with working_directory(config_dir):
+            working_dir = str(Path(seml_dict['project_root_dir']).expanduser().resolve())
         seml_dict['use_uploaded_sources'] = True
         with working_directory(working_dir): # use project root as base dir from now on
             executable_relative_to_project_root = os.path.exists(executable)


### PR DESCRIPTION
<!-- 
Thank you for contributing a pull request!
Please name and describe your PR as you would write a
commit message.
-->

### Reference issue
None created yet.

### What does this implement/fix?
The most recent commit e340dc4de0c472839fdda811e8b90d69fd6e54e0 introduces a new way of changing the working directory, when adding config files. 
Unfortunately a bug seems to have sneaked in, when evaluating the `project_root_dir` config variable. This is now evaluated relative to the current working directory of wherever seml was called from and not relative to the config as it was before. This means that if `project_root_dir` was previously set to a valid path when evaluated relative to the config (as in the examples) then this is now broken depending on where seml was called from. At least in my case where I have multiple folders of configuration files this broke all config files.
Evaluating the `project_root_dir` relative to the `config_dir` fixes the bug.


