### PR TITLE
List database and print fail trace

### DIFF
--- a/seml/database.py
+++ b/seml/database.py
@@ -309,15 +309,15 @@ def list_database(pattern, mongodb_config=None, progress=False, list_empty=False
         collection = db[collection_name]
         name_to_counts[collection_name] = Counter(exp['status'] for exp in collection.find({'status' : {'$exists' : True}}, {'status' : 1}))
     
-    columns = [States.STAGED[0], States.PENDING[0], States.RUNNING[0], States.FAILED[0], States.KILLED[0], States.INTERRUPTED[0], 
-               States.COMPLETED[0]]
+    columns = [States.STAGED, States.PENDING, States.RUNNING, States.FAILED, States.KILLED, States.INTERRUPTED, 
+               States.COMPLETED]
     table = PrettyTable()
-    table.field_names = ['Collection'] + [state for state in columns] + ['Total']
+    table.field_names = ['Collection'] + [states[0] for states in columns] + ['Total']
     for name, counts in name_to_counts.items():
-        if list_empty or any(counts[state] > 0 for state in columns):
-            table.add_row([name] + [counts[state] for state in columns] + [sum(counts.values())])
+        if list_empty or any(sum(counts[state] for state in states) > 0 for states in columns):
+            table.add_row([name] + [sum(counts[state] for state in states) for states in columns] + [sum(counts.values())])
     table.sortby = 'Collection'
     for field_name in table.field_names:
         table.align[field_name] = 'r'
     table.align['Collection'] = 'l'
-    print(table)
+    logging.info(table)

--- a/seml/database.py
+++ b/seml/database.py
@@ -5,7 +5,7 @@ import logging
 from tqdm.auto import tqdm
 import re
 from collections import Counter
-from prettytable import PrettyTable
+import pandas as pd
 
 from seml.utils import s_if
 from seml.settings import SETTINGS
@@ -311,13 +311,9 @@ def list_database(pattern, mongodb_config=None, progress=False, list_empty=False
     
     columns = [States.STAGED, States.PENDING, States.RUNNING, States.FAILED, States.KILLED, States.INTERRUPTED, 
                States.COMPLETED]
-    table = PrettyTable()
-    table.field_names = ['Collection'] + [states[0] for states in columns] + ['Total']
+    table = []
     for name, counts in name_to_counts.items():
         if list_empty or any(sum(counts[state] for state in states) > 0 for states in columns):
-            table.add_row([name] + [sum(counts[state] for state in states) for states in columns] + [sum(counts.values())])
-    table.sortby = 'Collection'
-    for field_name in table.field_names:
-        table.align[field_name] = 'r'
-    table.align['Collection'] = 'l'
-    logging.info(table)
+            table.append([name] + [sum(counts[state] for state in states) for states in columns] + [sum(counts.values())])
+    df = pd.DataFrame(table, columns=['Collection'] + [states[0] for states in columns] + ['Total']).set_index('Collection').sort_index()
+    logging.info(df.to_string())

--- a/seml/main.py
+++ b/seml/main.py
@@ -4,10 +4,10 @@ import json
 import logging
 
 from seml.manage import (report_status, cancel_experiments, delete_experiments, detect_killed, reset_experiments,
-                         mongodb_credentials_prompt, reload_sources)
+                         mongodb_credentials_prompt, reload_sources, print_fail_trace)
 from seml.add import add_config_files
 from seml.start import start_experiments, start_jupyter_job, print_command
-from seml.database import clean_unreferenced_artifacts
+from seml.database import clean_unreferenced_artifacts, list_database
 from seml.utils import LoggingFormatter
 from seml.settings import SETTINGS
 
@@ -63,6 +63,20 @@ def main():
             help='Display more log messages.')
 
     subparsers = parser.add_subparsers(title="Possible operations")
+    
+    parser_list_db = subparsers.add_parser(
+            "list",
+            help="Lists all collections in the database.")
+    parser_list_db.add_argument(
+            "-p", "--pattern",
+            help="A regex that must match the collections to print", type=str,
+            default=r'.*',
+    )
+    parser_list_db.add_argument(
+            "--progress-bar",
+            help="Whether to print a progress bar for iterating over collections", action='store_true', dest="progress"
+    )
+    parser_list_db.set_defaults(func=list_database)
 
     parser_clean_db = subparsers.add_parser(
             "clean-db",
@@ -140,6 +154,18 @@ def main():
             '-nw', '--no-worker', action='store_true',
             help="Do not launch a local worker after setting experiments' state to PENDING.")
     parser_start.set_defaults(func=start_experiments, set_to_pending=True)
+
+    parser_print_fail_trace = subparsers.add_parser(
+            "print-fail-trace",
+            help="Prints fail traces of all failed experiments."
+    )
+    parser_print_fail_trace.add_argument(
+            '-s', '--filter-states', type=str, nargs='*', default=[*States.FAILED, *States.KILLED,
+                                                                   *States.INTERRUPTED],
+            help="List of states to filter experiments by. "
+                 "Prints traces of all experiments if an empty list is passed. "
+                 "Default: Print failed, killed and interrupted experiments.")
+    parser_print_fail_trace.set_defaults(func=print_fail_trace)
 
 
     parser_reload = subparsers.add_parser(
@@ -243,7 +269,7 @@ def main():
     parser_detect.set_defaults(func=detect_killed)
 
     for subparser in [parser_start, parser_launch_worker, parser_print_command,
-                      parser_cancel, parser_delete, parser_reset]:
+                      parser_cancel, parser_delete, parser_reset, parser_print_fail_trace]:
         subparser.add_argument(
                 '-id', '--sacred-id', type=int,
                 help="Sacred ID (_id in the database collection) of the experiment. "
@@ -262,7 +288,6 @@ def main():
             '-y', '--yes', action='store_true',
             help="Automatically confirm all dialogues with yes."
         )
-
     commands = parse_args(parser, subparsers)
 
     # Initialize logging
@@ -277,8 +302,7 @@ def main():
         else:
             logging_level = logging.INFO
         logging.root.setLevel(logging_level)
-
-        if command.func in [mongodb_credentials_prompt, start_jupyter_job, parser.print_usage]:
+        if command.func in [mongodb_credentials_prompt, start_jupyter_job, list_database, parser.print_usage]:
             # No collection name required
             del command.db_collection_name
         elif command.func in [clean_unreferenced_artifacts]:

--- a/seml/main.py
+++ b/seml/main.py
@@ -29,9 +29,13 @@ def parse_args(parser, commands):
         parser.parse_args(split_argv[0])
     # Parse all subcommands
     commands = []
+    shared_args = split_argv[0]
+    if len(shared_args) == 0:
+        # Add empty collection if not provided
+        shared_args = ['']
     for argv in split_argv[1:]:
         # Copy the original arguments and the command specific ones
-        n = parser.parse_args(split_argv[0] + argv)
+        n = parser.parse_args(shared_args + argv)
         commands.append(n)
     return commands
 
@@ -68,7 +72,8 @@ def main():
             "list",
             help="Lists all collections in the database.")
     parser_list_db.add_argument(
-            "-p", "--pattern",
+            "pattern",
+            nargs="?",
             help="A regex that must match the collections to print", type=str,
             default=r'.*',
     )

--- a/seml/manage.py
+++ b/seml/manage.py
@@ -510,5 +510,6 @@ def print_fail_trace(db_collection_name, sacred_id, filter_states, batch_id, fil
         slurm_array_id = exp.get('slurm', {}).get('array_id', None)
         slurm_task_id = exp.get('slurm', {}).get('task_id', None)
         fail_trace = exp.get('fail_trace', [])
-        print(f'***** Experiment ID {exp_id}, status: {status}, slurm array-id, task-id: {slurm_array_id}-{slurm_task_id} *****')
-        print(''.join(['\t' + line for line in fail_trace] + []))
+        logging.info(f'***** Experiment ID {exp_id}, status: {status}, slurm array-id, task-id: {slurm_array_id}-{slurm_task_id} *****')
+        logging.info(''.join(['\t' + line for line in fail_trace] + []))
+    logging.info(f'Printed the fail traces of {len(exps)} experiment(s).')

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ install_requires = [
     "munch>=2.0.4",
     "tqdm>=4.36",
     "debugpy>=1.2.1",
-    "requests>=2.28.1"
-    "prettytable",
+    "requests>=2.28.1",
 ]
 
 with open("README.md", "r") as fh:

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ install_requires = [
     "tqdm>=4.36",
     "debugpy>=1.2.1",
     "requests>=2.28.1"
+    "prettytable",
 ]
 
 with open("README.md", "r") as fh:


### PR DESCRIPTION
<!-- 
Thank you for contributing a pull request!
Please name and describe your PR as you would write a
commit message.
-->


### What does this implement/fix?
This PR adds two convenience functions to SEML:

#### Listing
`seml list [pattern]` will list all collections in the database that matches an (optional) RegEx pattern. It will also print the state counts for all experiments in the collection. Note that in contrast to `seml {collection} status`, it does not verify that experiments with state `RUNNING` are actually still running and have not died or been interupted. This is to ensure the command runs quickly.

Example output:
```bash
seml list .*_pneuma
WARNING: Status of RUNNING experiments may not reflect if they have died or been canceled. Use `seml ... status` instead.
+------------+--------+---------+---------+--------+--------+-------------+-----------+-------+
| Collection | STAGED | PENDING | RUNNING | FAILED | KILLED | INTERRUPTED | COMPLETED | Total |
+------------+--------+---------+---------+--------+--------+-------------+-----------+-------+
| gat_pneuma |      0 |       0 |       0 |      7 |      0 |           0 |        65 |    72 |
| gcn_pneuma |      0 |       0 |       2 |      1 |      0 |           0 |        45 |    48 |
| hpo_pneuma |      0 |       0 |       0 |     24 |     49 |           0 |        47 |   120 |
+------------+--------+---------+---------+--------+--------+-------------+-----------+-------+
```
#### Fail Trace Printing
`seml {collection} print-fail-trace` will print the fail trace of all experiments with "failed states" (`FAILED`, `KILLED`, `INTERRUPTED`). This way, you don't have to use a MongoDB client everytime you want to inspect error logs.

Example output (shortened, to only show the output format):
```bash
seml gat_pneuma print-fail-trace
***** Experiment ID 1, status: FAILED, slurm array-id, task-id: 7921342-0 *****
        Traceback (most recent call last):
          File "/nfs/staff-ssd/fuchsgru/miniconda3/envs/trajectory_gnn/lib/python3.10/site-packages/hydra/_internal/instantiate/_instantiate2.py", line 92, in _call_target
    ...
TypeError("new() received an invalid combination of arguments - got (str, int), but expected one of:\n * (*, torch.device device)\n      didn't match because some of the arguments have invalid types: (\x1b[31;1mstr\x1b[0m, \x1b[31;1mint\x1b[0m)\n * (torch.Storage storage)\n * (Tensor other)\n * (tuple of ints size, *, torch.device device)\n * (object data, *, torch.device device)\n")
full_key: model.layers0

***** Experiment ID 35, status: FAILED, slurm array-id, task-id: 7930611-2 *****
        Traceback (most recent call last):
          File "/nfs/homedirs/fuchsgru/seml/seml/hydra.py", line 98, in decorator
    result = func(cfg)
          ...
        torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 1.75 GiB (GPU 0; 39.59 GiB total capacity; 37.05 GiB already allocated; 1.21 GiB free; 37.14 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF

...
```
