### PR TITLE
Reimplement CLI with typer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,28 @@ Then configure your MongoDB via:
 seml configure  --mongodb # provide your MongoDB credentials
 ```
 
+### Formatting
+To improve CLI formatting of `seml` install it with `rich` via:
+```bash
+pip install seml[all]
+``` 
+
+## Documentation
+Documentation is available in our [docs.md](docs.md) or via the CLI:
+```python
+seml --help
+```
+
 ## Example
 See our simple [example](examples) to get familiar with how **`SEML`** works.
 
 ## CLI completion
 SEML supports (rudimentary) command line completion. To install this feature run:
 ```bash
-seml configure --argcomplete
+seml --install-completion
 ```
-There are three options available, we recommend to install the completion as `user`:
-- `user`: Creates `~/.bash_completion`, which will be automatically sourced when a shell is opened
-- `global`: Creates a similar file at a [suitable location](https://pypi.org/project/argcomplete/) depending on the shell being used. You need sudo rights to install argument completion globally.
-- `path`: Queries for a specific path to which to install the argument completion script. This script needs to be sourced in every shell session in which argument completion is to be used.
-In the background, this feature relies on the [argcomplete](https://pypi.org/project/argcomplete/) module. To disable and purge the feature you should uninstall this module and delete (the relevant parts of) the file created by `seml configure --argcomplete` (which depends on the installation mode you chose).
+
+Note: Autocompletition is not supported by chaining, i.e., only the first command will have autocompletion.
 
 
 ## Slurm version

--- a/docs.md
+++ b/docs.md
@@ -1,0 +1,328 @@
+# `seml`
+
+SEML - Slurm Experiment Management Library.
+
+**Usage**:
+
+```console
+$ seml [OPTIONS] COLLECTION COMMAND [ARGS]...
+```
+
+**Arguments**:
+
+* `COLLECTION`: The name of the database collection to use.  [required]
+
+**Options**:
+
+* `-v, --verbose`: Whether to print debug messages.
+* `--install-completion`: Install completion for the current shell.
+* `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `add`: Add experiments to the database as defined...
+* `cancel`: Cancel the Slurm job/job step...
+* `clean-db`: Remove orphaned artifacts in the DB from...
+* `configure`: Configure SEML (database, argument...
+* `delete`: Delete experiments by ID or state (does...
+* `detect-killed`: Detect experiments where the corresponding...
+* `launch-worker`: Launch a local worker that runs PENDING jobs.
+* `list`: Lists all collections in the database.
+* `print-fail-trace`: Prints fail traces of all failed experiments.
+* `print_command`: Print the commands that would be executed...
+* `reload-sources`: Reload stashed source files.
+* `reset`: Reset the state of experiments by setting...
+* `start`: Fetch staged experiments from the database...
+* `start-jupyter`: Start a Jupyter slurm job.
+* `status`: Report status of experiments in the...
+
+## `seml add`
+
+Add experiments to the database as defined in the configuration.
+
+**Usage**:
+
+```console
+$ seml add [OPTIONS] CONFIG_FILES...
+```
+
+**Arguments**:
+
+* `CONFIG_FILES...`: Path to the YAML configuration file for the experiment.  [required]
+
+**Options**:
+
+* `--hash / --no-hash`: Use the hash of the config dictionary to filter out duplicates (by comparing all dictionary values individually). Only disable this if you have a good reason as it is faster.  [default: hash]
+* `--sanity-check / --no-sanity-check`: Check the config for missing/unused arguments. Disable this if the check fails unexpectedly when using advanced Sacred features or to accelerate adding.  [default: sanity-check]
+* `--code-checkpoint / --no-code-checkpoint`: Save a checkpoint of the code in the database. Disable this if you want your experiments to use the current codeinstead of the code at the time of adding.  [default: code-checkpoint]
+* `--force / --no-force`: Force adding the experiment even if it already exists in the database.  [default: no-force]
+* `--overwrite-params JSON`: Dictionary (passed as a string, e.g. '{"epochs": 100}') to overwrite parameters in the config.
+* `--help`: Show this message and exit.
+
+## `seml cancel`
+
+Cancel the Slurm job/job step corresponding to experiments, filtered by ID or state.
+
+**Usage**:
+
+```console
+$ seml cancel [OPTIONS]
+```
+
+**Options**:
+
+* `-id, --sacred-id INTEGER`: Sacred ID (_id in the database collection) of the experiment. Takes precedence over other filters.
+* `-f, --filter-dict JSON`: Dictionary (passed as a string, e.g. '{"config.dataset": "cora_ml"}') to filter the experiments by.
+* `-b, --batch-id INTEGER`: Batch ID (batch_id in the database collection) of the experiments. Experiments that were staged together have the same batch_id.
+* `-s, --filter-states [STAGED|QUEUED|PENDING|RUNNING|FAILED|KILLED|INTERRUPTED|COMPLETED]`: List of states to filter the experiments by. If empty (""), all states are considered.  [default: PENDING, RUNNING]
+* `-w, --wait`: Wait until all jobs are properly cancelled.
+* `-y, --yes`: Automatically confirm all dialogues with yes.
+* `--help`: Show this message and exit.
+
+## `seml clean-db`
+
+Remove orphaned artifacts in the DB from runs which have been deleted..
+
+**Usage**:
+
+```console
+$ seml clean-db [OPTIONS]
+```
+
+**Options**:
+
+* `-y, --yes`: Automatically confirm all dialogues with yes.
+* `--help`: Show this message and exit.
+
+## `seml configure`
+
+Configure SEML (database, argument completion, ...).
+
+**Usage**:
+
+```console
+$ seml configure [OPTIONS]
+```
+
+**Options**:
+
+* `--all / --no-all`: Configure all SEML settings  [default: no-all]
+* `--mongodb / --no-mongodb`: Configure MongoDB settings  [default: mongodb]
+* `--help`: Show this message and exit.
+
+## `seml delete`
+
+Delete experiments by ID or state (does not cancel Slurm jobs).
+
+**Usage**:
+
+```console
+$ seml delete [OPTIONS]
+```
+
+**Options**:
+
+* `-id, --sacred-id INTEGER`: Sacred ID (_id in the database collection) of the experiment. Takes precedence over other filters.
+* `-s, --filter-states [STAGED|QUEUED|PENDING|RUNNING|FAILED|KILLED|INTERRUPTED|COMPLETED]`: List of states to filter the experiments by. If empty (""), all states are considered.  [default: STAGED, QUEUED, FAILED, KILLED, INTERRUPTED]
+* `-f, --filter-dict JSON`: Dictionary (passed as a string, e.g. '{"config.dataset": "cora_ml"}') to filter the experiments by.
+* `-b, --batch-id INTEGER`: Batch ID (batch_id in the database collection) of the experiments. Experiments that were staged together have the same batch_id.
+* `-y, --yes`: Automatically confirm all dialogues with yes.
+* `--help`: Show this message and exit.
+
+## `seml detect-killed`
+
+Detect experiments where the corresponding Slurm jobs were killed externally.
+
+**Usage**:
+
+```console
+$ seml detect-killed [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+## `seml launch-worker`
+
+Launch a local worker that runs PENDING jobs.
+
+**Usage**:
+
+```console
+$ seml launch-worker [OPTIONS]
+```
+
+**Options**:
+
+* `-n, --num-experiments INTEGER`: Number of experiments to start. 0: all (staged) experiments   [default: 0]
+* `--file-output / --no-file-output`: Write the experiment's output to a file.  [default: file-output]
+* `-ss, --steal-slurm`: Local jobs 'steal' from the Slurm queue, i.e. also execute experiments waiting for execution via Slurm.
+* `-pm, --post-mortem`: Activate post-mortem debugging with pdb.
+* `--output-to-console / --no-output-to-console`: Write the experiment's output to the console.  [default: no-output-to-console]
+* `-wg, --worker-gpus TEXT`: The IDs of the GPUs used by the local worker. Will be directly passed to CUDA_VISIBLE_DEVICES.
+* `-wc, --worker-cpus INTEGER`: The number of CPUs used by the local worker. Will be directly passed to OMP_NUM_THREADS.
+* `-we, --worker-env JSON`: Further environment variables to be set for the local worker.
+* `-id, --sacred-id INTEGER`: Sacred ID (_id in the database collection) of the experiment. Takes precedence over other filters.
+* `-f, --filter-dict JSON`: Dictionary (passed as a string, e.g. '{"config.dataset": "cora_ml"}') to filter the experiments by.
+* `-b, --batch-id INTEGER`: Batch ID (batch_id in the database collection) of the experiments. Experiments that were staged together have the same batch_id.
+* `--help`: Show this message and exit.
+
+## `seml list`
+
+Lists all collections in the database.
+
+**Usage**:
+
+```console
+$ seml list [OPTIONS] [PATTERN]
+```
+
+**Arguments**:
+
+* `[PATTERN]`: A regex that must match the collections to print.  [default: .*]
+
+**Options**:
+
+* `-p, --progress`: Whether to print a progress bar for iterating over collections.
+* `--help`: Show this message and exit.
+
+## `seml print-fail-trace`
+
+Prints fail traces of all failed experiments.
+
+**Usage**:
+
+```console
+$ seml print-fail-trace [OPTIONS]
+```
+
+**Options**:
+
+* `-id, --sacred-id INTEGER`: Sacred ID (_id in the database collection) of the experiment. Takes precedence over other filters.
+* `-f, --filter-dict JSON`: Dictionary (passed as a string, e.g. '{"config.dataset": "cora_ml"}') to filter the experiments by.
+* `-b, --batch-id INTEGER`: Batch ID (batch_id in the database collection) of the experiments. Experiments that were staged together have the same batch_id.
+* `-s, --filter-states [STAGED|QUEUED|PENDING|RUNNING|FAILED|KILLED|INTERRUPTED|COMPLETED]`: List of states to filter the experiments by. If empty (""), all states are considered.  [default: FAILED, KILLED, INTERRUPTED]
+* `-y, --yes`: Automatically confirm all dialogues with yes.
+* `--help`: Show this message and exit.
+
+## `seml print_command`
+
+Print the commands that would be executed by `start`.
+
+**Usage**:
+
+```console
+$ seml print_command [OPTIONS]
+```
+
+**Options**:
+
+* `-id, --sacred-id INTEGER`: Sacred ID (_id in the database collection) of the experiment. Takes precedence over other filters.
+* `-f, --filter-dict JSON`: Dictionary (passed as a string, e.g. '{"config.dataset": "cora_ml"}') to filter the experiments by.
+* `-b, --batch-id INTEGER`: Batch ID (batch_id in the database collection) of the experiments. Experiments that were staged together have the same batch_id.
+* `-n, --num-experiments INTEGER`: Number of experiments to start. 0: all (staged) experiments   [default: 0]
+* `-wg, --worker-gpus TEXT`: The IDs of the GPUs used by the local worker. Will be directly passed to CUDA_VISIBLE_DEVICES.
+* `-wc, --worker-cpus INTEGER`: The number of CPUs used by the local worker. Will be directly passed to OMP_NUM_THREADS.
+* `-we, --worker-env JSON`: Further environment variables to be set for the local worker.
+* `--help`: Show this message and exit.
+
+## `seml reload-sources`
+
+Reload stashed source files.
+
+**Usage**:
+
+```console
+$ seml reload-sources [OPTIONS]
+```
+
+**Options**:
+
+* `-k, -keep-old`: Keep the old source files in the database.
+* `-b, --batch-ids INTEGER`: Batch IDs (batch_id in the database collection) of the experiments. Experiments that were staged together have the same batch_id.
+* `-y, --yes`: Automatically confirm all dialogues with yes.
+* `--help`: Show this message and exit.
+
+## `seml reset`
+
+Reset the state of experiments by setting their state to STAGED and cleaning their database entry.
+Does not cancel Slurm jobs.
+
+**Usage**:
+
+```console
+$ seml reset [OPTIONS]
+```
+
+**Options**:
+
+* `-id, --sacred-id INTEGER`: Sacred ID (_id in the database collection) of the experiment. Takes precedence over other filters.
+* `-s, --filter-states [STAGED|QUEUED|PENDING|RUNNING|FAILED|KILLED|INTERRUPTED|COMPLETED]`: List of states to filter the experiments by. If empty (""), all states are considered.  [default: FAILED, KILLED, INTERRUPTED]
+* `-f, --filter-dict JSON`: Dictionary (passed as a string, e.g. '{"config.dataset": "cora_ml"}') to filter the experiments by.
+* `-b, --batch-id INTEGER`: Batch ID (batch_id in the database collection) of the experiments. Experiments that were staged together have the same batch_id.
+* `-y, --yes`: Automatically confirm all dialogues with yes.
+* `--help`: Show this message and exit.
+
+## `seml start`
+
+Fetch staged experiments from the database and run them (by default via Slurm).
+
+**Usage**:
+
+```console
+$ seml start [OPTIONS]
+```
+
+**Options**:
+
+* `-id, --sacred-id INTEGER`: Sacred ID (_id in the database collection) of the experiment. Takes precedence over other filters.
+* `-f, --filter-dict JSON`: Dictionary (passed as a string, e.g. '{"config.dataset": "cora_ml"}') to filter the experiments by.
+* `-b, --batch-id INTEGER`: Batch ID (batch_id in the database collection) of the experiments. Experiments that were staged together have the same batch_id.
+* `-d, --debug`: Run a single interactive experiment without Sacred observers and with post-mortem debugging. Implies `--verbose --num-exps 1 --post-mortem --output-to-console`.
+* `-ds, --debug-server`: Run the experiment with a debug server, to which you can remotely connect with e.g. VS Code. Implies `--debug`.
+* `-l, --local`: Run the experiment locally instead of on a Slurm cluster.
+* `-nw, --no-worker`: Do not launch a local worker after setting experiments' state to PENDING.
+* `-n, --num-experiments INTEGER`: Number of experiments to start. 0: all (staged) experiments   [default: 0]
+* `--file-output / --no-file-output`: Write the experiment's output to a file.  [default: file-output]
+* `-ss, --steal-slurm`: Local jobs 'steal' from the Slurm queue, i.e. also execute experiments waiting for execution via Slurm.
+* `-pm, --post-mortem`: Activate post-mortem debugging with pdb.
+* `--output-to-console / --no-output-to-console`: Write the experiment's output to the console.  [default: no-output-to-console]
+* `-wg, --worker-gpus TEXT`: The IDs of the GPUs used by the local worker. Will be directly passed to CUDA_VISIBLE_DEVICES.
+* `-wc, --worker-cpus INTEGER`: The number of CPUs used by the local worker. Will be directly passed to OMP_NUM_THREADS.
+* `-we, --worker-env JSON`: Further environment variables to be set for the local worker.
+* `--help`: Show this message and exit.
+
+## `seml start-jupyter`
+
+Start a Jupyter slurm job. Uses SBATCH options defined in settings.py under
+SBATCH_OPTIONS_TEMPLATES.JUPYTER
+
+**Usage**:
+
+```console
+$ seml start-jupyter [OPTIONS]
+```
+
+**Options**:
+
+* `-l, --lab`: Start a jupyter-lab instance instead of jupyter notebook.
+* `-c, --conda-env TEXT`: Start the Jupyter instance in a Conda environment.
+* `-sb, --sbatch-options JSON`: Dictionary (passed as a string, e.g. '{"gres": "gpu:2"}') to request two GPUs.
+* `--help`: Show this message and exit.
+
+## `seml status`
+
+Report status of experiments in the database collection.
+
+**Usage**:
+
+```console
+$ seml status [OPTIONS]
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+

--- a/seml/configure.py
+++ b/seml/configure.py
@@ -1,80 +1,22 @@
-import getpass
 import logging
-import os
-from pathlib import Path
-from typing import Iterable, Optional
 
-from seml.errors import ArgumentError
+from typer import prompt
+
 from seml.settings import SETTINGS
 
 
-def get_input(field_name: Optional[str]=None, num_trials=3, password: bool=False,
-                       choices: Optional[Iterable[str]]=None, default=None, nonempty: bool=True,
-                       existing_path: bool=False,
-                       prompt: Optional[str]=None) -> str:
-    get_input = getpass if password else input
-    for _ in range(num_trials):
-        prompt = prompt or f"Please input the {field_name}"
-        if choices is not None and len(choices) > 0:
-            prompt += f', (one of [{", ".join(map(str, choices))}])'
-        if default:
-            prompt += f", default={default}"
-        prompt += ": "
-        field = get_input(prompt)
-        if not field:
-            field = default
-        if nonempty and (field is None or len(field) == 0):
-            logging.error(f'{field_name} was empty.')
-            continue
-        if choices is not None and field not in choices:
-            logging.error(f'{field_name} must be one of {choices}')
-            continue
-        if existing_path and not Path(field).expanduser().resolve().exists():
-            logging.error(f'Path {Path(field)} does not exist.')
-            continue
-        return field
-    else:
-        raise ArgumentError(f"Did not receive an input for {num_trials} times. Aborting.")
-
-
-ARGCOMPLETE_GLOBAL = 'global'
-ARGCOMPLETE_USER = 'user'
-ARGCOMPLETE_PATH = 'path'
-
-
-def argcomplete_configure():
-    """ Initializes argument completion. """
-    logging.info('Configuring argument completion.')
-    mode = get_input(prompt='Enter how argument completion should be registered', 
-                     choices=[ARGCOMPLETE_USER, ARGCOMPLETE_GLOBAL, ARGCOMPLETE_PATH], default=ARGCOMPLETE_USER)
-    if mode == ARGCOMPLETE_GLOBAL:
-        cmd = 'activate-global-python-argcomplete'
-    elif mode == ARGCOMPLETE_USER:
-        cmd = 'activate-global-python-argcomplete --user'
-    elif mode == ARGCOMPLETE_PATH:
-        path = get_input(prompt='Enter the shell completion modules directory to install to', existing_path=True)
-        path = str(Path(path).expanduser().resolve())
-        cmd = f'activate-global-python-argcomplete --dest {path}'
-    else:
-        raise ValueError(mode)
-    logging.info(f'Running {cmd}')
-    os.system(cmd)
-
-
 def mongodb_configure(): 
-    import click
-    if SETTINGS.DATABASE.MONGODB_CONFIG_PATH.exists() and not click.confirm(
-        f'MongoDB configuration {SETTINGS.DATABASE.MONGODB_CONFIG_PATH} already exists and will be overwritten. Continue?',
-        default=False
+    if SETTINGS.DATABASE.MONGODB_CONFIG_PATH.exists() and not prompt(
+        f'MongoDB configuration {SETTINGS.DATABASE.MONGODB_CONFIG_PATH} already exists and will be overwritten.\nContinue?',
+        type=bool
     ):
         return
     logging.info('Configuring MongoDB. Warning: Password will be stored in plain text.')
-    host = get_input("MongoDB host")
-    port = input('Port (default: 27017):')
-    port = "27017" if port == "" else port
-    database = get_input("database name")
-    username = get_input("user name")
-    password = get_input("password", password=True)
+    host = prompt("MongoDB host")
+    port = prompt("Port", default="27017")
+    database = prompt("Database name")
+    username = prompt("User name")
+    password = prompt("Password", hide_input=True)
     file_path = SETTINGS.DATABASE.MONGODB_CONFIG_PATH
     config_string = (f'username: {username}\n'
                      f'password: {password}\n'
@@ -89,13 +31,10 @@ def mongodb_configure():
         f.write(config_string)
 
 
-def configure(all: bool=False, mongodb: bool=False, argcomplete: bool=False):
+def configure(all: bool=False, mongodb: bool=False):
     configured_any = False
     if mongodb or all:
         mongodb_configure()
-        configured_any = True
-    if argcomplete or all:
-        argcomplete_configure()
         configured_any = True
     if not configured_any:
         logging.info('Did not specify any configuration to configure')

--- a/seml/main.py
+++ b/seml/main.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python
-# PYTHON_ARGCOMPLETE_OK
-import argparse
+import functools
 import json
 import logging
 import sys
+from pathlib import Path
+from typing import List
 
-import argcomplete
-from argcomplete.completers import FilesCompleter
+import typer
+from typing_extensions import Annotated
 
 from seml.add import add_config_files
 from seml.configure import configure
-from seml.database import clean_unreferenced_artifacts, list_database, get_mongodb_config, get_collections_from_mongo_shell_or_pymongo
+from seml.database import (clean_unreferenced_artifacts,
+                           get_collections_from_mongo_shell_or_pymongo,
+                           get_mongodb_config, list_database)
 from seml.manage import (cancel_experiments, delete_experiments, detect_killed,
-                         print_fail_trace,
-                         reload_sources, report_status, reset_experiments)
+                         print_fail_trace, reload_sources, report_status,
+                         reset_experiments)
 from seml.settings import SETTINGS
 from seml.start import print_command, start_experiments, start_jupyter_job
 from seml.utils import LoggingFormatter
@@ -21,333 +24,654 @@ from seml.utils import LoggingFormatter
 States = SETTINGS.STATES
 
 
-def DbCollectionCompleter(**kwargs):
+def db_collection_completer():
     """ CLI completion for db collections. """
     config = get_mongodb_config()
     return list(get_collections_from_mongo_shell_or_pymongo(**config))
 
 
-def parse_args(parser, commands):
-    # https://stackoverflow.com/a/43927360
+app = typer.Typer(no_args_is_help=True)
+YesAnnotation = Annotated[bool, typer.Option(
+    '-y',
+    '--yes',
+    help="Automatically confirm all dialogues with yes.",
+)]
+SacredIdAnnotation = Annotated[int, typer.Option(
+    '-id',
+    '--sacred-id',
+    help="Sacred ID (_id in the database collection) of the experiment. "
+            "Takes precedence over other filters.",
+)]
+FilterDictAnnotation = Annotated[dict, typer.Option(
+    '-f',
+    '--filter-dict',
+    help="Dictionary (passed as a string, e.g. '{\"config.dataset\": \"cora_ml\"}') to filter "
+            "the experiments by.",
+    metavar='JSON',
+    parser=json.loads,
+)]
+BatchIdAnnotation = Annotated[int, typer.Option(
+    '-b',
+    '--batch-id',
+    help="Batch ID (batch_id in the database collection) of the experiments. "
+            "Experiments that were staged together have the same batch_id.",
+)]
+
+_STATE_LIST = [s for states in States.values() for s in states]
+FilterStatesAnnotation = Annotated[List[str], typer.Option(
+    '-s',
+    '--filter-states',
+    help='List of states to filter the experiments by. If empty (""), all states are considered.',
+    metavar=f'[{"|".join(_STATE_LIST)}]',
+    parser=lambda s: s.strip().upper(),
+    callback=lambda values: [
+        __x.strip().upper()
+        for _x in values
+        for __x in _x.replace(',', ' ').split()
+        if __x
+    ],
+)]
+SBatchOptionsAnnotation = Annotated[dict, typer.Option(
+    '-sb',
+    '--sbatch-options',
+    help="Dictionary (passed as a string, e.g. '{\"gres\": \"gpu:2\"}') to request two GPUs.",
+    metavar='JSON',
+    parser=json.loads
+)]
+NumExperimentsAnnotation = Annotated[int, typer.Option(
+    '-n',
+    '--num-experiments',
+    help="Number of experiments to start. "
+            "0: all (staged) experiments ",
+)]
+FileOutputAnnotation = Annotated[
+    bool,
+    typer.Option(
+        help="Write the experiment's output to a file.",
+    )
+]
+OutputToConsoleAnnotation = Annotated[
+    bool,
+    typer.Option(
+        help="Write the experiment's output to the console.",
+    )
+]
+StealSlurmAnnotation = Annotated[
+    bool,
+    typer.Option(
+        '-ss',
+        '--steal-slurm',
+        help="Local jobs 'steal' from the Slurm queue, "
+            "i.e. also execute experiments waiting for execution via Slurm.",
+    )
+]
+PostMortemAnnotation = Annotated[
+    bool,
+    typer.Option(
+        '-pm',
+        '--post-mortem',
+        help="Activate post-mortem debugging with pdb.",
+    )
+]
+WorkerGPUsAnnotation = Annotated[
+    str,
+    typer.Option(
+        '-wg',
+        '--worker-gpus',
+        help="The IDs of the GPUs used by the local worker. Will be directly passed to CUDA_VISIBLE_DEVICES.",
+    )
+]
+WorkerCPUsAnnotation = Annotated[
+    int,
+    typer.Option(
+        '-wc',
+        '--worker-cpus',
+        help="The number of CPUs used by the local worker. Will be directly passed to OMP_NUM_THREADS.",
+    )
+]
+WorkerEnvAnnotation = Annotated[
+    dict,
+    typer.Option(
+        '-we',
+        '--worker-env',
+        help="Further environment variables to be set for the local worker.",
+        metavar='JSON',
+        parser=json.loads
+    )
+]
+
+
+
+@app.callback()
+def callback(
+    ctx: typer.Context,
+    collection: Annotated[
+        str,
+        typer.Argument(
+            help="The name of the database collection to use.",
+            autocompletion=db_collection_completer
+        )
+    ],
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            '-v',
+            '--verbose',
+            help="Whether to print debug messages."
+        )
+    ] = False
+):
+    """SEML - Slurm Experiment Management Library."""
+    if len(logging.root.handlers) == 0:
+        try:
+            from rich.logging import RichHandler
+            handler = RichHandler(
+                logging.VERBOSE if verbose else logging.INFO,
+                show_path=False,
+                show_level=True,
+                show_time=False,
+            )
+            logging.basicConfig(
+                level="NOTSET", format="%(message)s", handlers=[handler]
+            )
+        except ImportError:
+            hdlr = logging.StreamHandler(sys.stderr)
+            hdlr.setFormatter(LoggingFormatter())
+            logging.root.addHandler(hdlr)
+            if verbose:
+                logging_level = logging.VERBOSE
+            else:
+                logging_level = logging.INFO
+            logging.root.setLevel(logging_level)
+
+    ctx.obj = dict(
+        collection=collection,
+        verbose=verbose
+    )
+
+
+@app.command("list")
+def list_command(
+    ctx: typer.Context,
+    pattern: Annotated[str, typer.Argument(
+        help="A regex that must match the collections to print."
+    )] = r'.*',
+    progress: Annotated[bool, typer.Option(
+        '-p',
+        '--progress',
+        help="Whether to print a progress bar for iterating over collections."
+    )] = False
+):
+    """Lists all collections in the database."""
+    assert not ctx.obj['collection'], "Collection name should not be passed to this command."
+    list_database(pattern, progress=progress)
+
+
+@app.command("clean-db")
+def clean_db_command(
+    ctx: typer.Context,
+    yes: YesAnnotation = False
+):
+    """Remove orphaned artifacts in the DB from runs which have been deleted.."""
+    clean_unreferenced_artifacts(ctx.obj['collection'], yes=yes)
+
+
+@app.command("configure")
+def configure_command(
+    ctx: typer.Context,
+    all: Annotated[
+        bool,
+        typer.Option(
+            help="Configure all SEML settings",
+        ),
+    ] = False,
+    mongodb: Annotated[
+        bool,
+        typer.Option(
+            help="Configure MongoDB settings",
+        ),
+    ] = True
+):
+    """
+    Configure SEML (database, argument completion, ...).
+    """
+    assert not ctx.obj['collection'], "Collection name should not be passed to this command."
+    configure(all=all, mongodb=mongodb)
+
+
+@app.command("start-jupyter")
+def start_jupyter_command(
+    ctx: typer.Context,
+    lab: Annotated[
+        bool,
+        typer.Option(
+            '-l',
+            '--lab',
+            help="Start a jupyter-lab instance instead of jupyter notebook.",
+        ),
+    ] = False,
+    conda_env: Annotated[
+        str,
+        typer.Option(
+            '-c',
+            '--conda-env',
+            help="Start the Jupyter instance in a Conda environment.",
+        ),
+    ] = None,
+    sbatch_options: SBatchOptionsAnnotation = None
+):
+    """
+    Start a Jupyter slurm job. Uses SBATCH options defined in settings.py under
+    SBATCH_OPTIONS_TEMPLATES.JUPYTER
+    """
+    assert not ctx.obj['collection'], "Collection name should not be passed to this command."
+    start_jupyter_job(lab=lab, conda_env=conda_env, sbatch_options=sbatch_options)
+
+
+@app.command("cancel")
+def cancel_command(
+    ctx: typer.Context,
+    sacred_id: SacredIdAnnotation = None,
+    filter_dict: FilterDictAnnotation = None,
+    batch_id: BatchIdAnnotation = None,
+    filter_states: FilterStatesAnnotation = [*States.PENDING, *States.RUNNING],
+    wait: Annotated[
+        bool,
+        typer.Option(
+            '-w',
+            '--wait',
+            help="Wait until all jobs are properly cancelled.",
+        ),
+    ] = False,
+    yes: YesAnnotation = False
+):
+    """
+    Cancel the Slurm job/job step corresponding to experiments, filtered by ID or state.
+    """
+    assert ctx.obj['collection'], "Collection name must be passed to this command."
+    wait = wait or len([a for a in sys.argv if a in command_names(app)]) > 1
+    cancel_experiments(
+        ctx.obj['collection'],
+        sacred_id=sacred_id,
+        filter_dict=filter_dict,
+        batch_id=batch_id,
+        filter_states=filter_states,
+        wait=wait,
+        yes=yes
+    )
+
+
+@app.command("add")
+def add_command(
+    ctx: typer.Context,
+    config_files: Annotated[
+        List[Path],
+        typer.Argument(
+            help="Path to the YAML configuration file for the experiment.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+        ),
+    ],
+    hash: Annotated[
+        bool,
+        typer.Option(
+            help="Use the hash of the config dictionary to filter out duplicates (by comparing all "
+                 "dictionary values individually). Only disable this if you have a good reason as it is faster.",
+        ),
+    ] = True,
+    sanity_check: Annotated[
+        bool,
+        typer.Option(
+            help="Check the config for missing/unused arguments. "
+                 "Disable this if the check fails unexpectedly when using "
+                 "advanced Sacred features or to accelerate adding.",
+        ),
+    ] = True,
+    code_checkpoint: Annotated[
+        bool,
+        typer.Option(
+            help="Save a checkpoint of the code in the database. "
+                    "Disable this if you want your experiments to use the current code"
+                    "instead of the code at the time of adding.",
+        ),
+    ] = True,
+    force: Annotated[
+        bool,
+        typer.Option(
+            help="Force adding the experiment even if it already exists in the database.",
+        ),
+    ] = False,
+    overwrite_params: Annotated[
+        dict,
+        typer.Option(
+            help="Dictionary (passed as a string, e.g. '{\"epochs\": 100}') to overwrite parameters in the config.",
+            metavar='JSON',
+            parser=json.loads
+        ),
+    ] = None,
+):
+    """
+    Add experiments to the database as defined in the configuration.
+    """
+    assert ctx.obj['collection'], "Collection name must be passed to this command."
+    add_config_files(
+        ctx.obj['collection'],
+        config_files,
+        force_duplicates=force,
+        no_hash=not hash,
+        no_sanity_check=not sanity_check,
+        no_code_checkpoint=not code_checkpoint,
+        overwrite_params=overwrite_params
+    )
+
+@app.command("start")
+def start_command(
+    ctx: typer.Context,
+    sacred_id: SacredIdAnnotation = None,
+    filter_dict: FilterDictAnnotation = None,
+    batch_id: BatchIdAnnotation = None,
+    debug: Annotated[
+        bool,
+        typer.Option(
+            '-d',
+            '--debug',
+            help="Run a single interactive experiment without Sacred observers and with post-mortem debugging. "
+                 "Implies `--verbose --num-exps 1 --post-mortem --output-to-console`.",
+        ),
+    ] = False,
+    debug_server: Annotated[
+        bool,
+        typer.Option(
+            '-ds',
+            '--debug-server',
+            help="Run the experiment with a debug server, to which you can remotely connect with e.g. VS Code. "
+                 "Implies `--debug`.",
+        ),
+    ] = False,
+    local: Annotated[
+        bool,
+        typer.Option(
+            '-l',
+            '--local',
+            help="Run the experiment locally instead of on a Slurm cluster.",
+        ),
+    ] = False,
+    no_worker: Annotated[
+        bool,
+        typer.Option(
+            '-nw',
+            '--no-worker',
+            help="Do not launch a local worker after setting experiments' state to PENDING.",
+        ),
+    ] = False,
+    num_exps: NumExperimentsAnnotation = 0,
+    file_output: FileOutputAnnotation = True,
+    steal_slurm: StealSlurmAnnotation = False,
+    post_mortem: PostMortemAnnotation = False,
+    output_to_console: OutputToConsoleAnnotation = False,
+    worker_gpus: WorkerGPUsAnnotation = None,
+    worker_cpus: WorkerCPUsAnnotation = None,
+    worker_env: WorkerEnvAnnotation = None,
+):
+    """
+    Fetch staged experiments from the database and run them (by default via Slurm).
+    """
+    assert ctx.obj['collection'], "Collection name must be passed to this command."
+    start_experiments(
+        ctx.obj['collection'],
+        local=local,
+        sacred_id=sacred_id,
+        batch_id=batch_id,
+        filter_dict=filter_dict,
+        num_exps=num_exps,
+        post_mortem=post_mortem,
+        debug=debug,
+        debug_server=debug_server,
+        output_to_console=output_to_console,
+        no_file_output=not file_output,
+        steal_slurm=steal_slurm,
+        no_worker=no_worker,
+        set_to_pending=True,
+        worker_gpus=worker_gpus,
+        worker_cpus=worker_cpus,
+        worker_environment_vars=worker_env,
+    )
+
+
+@app.command("launch-worker")
+def launch_worker_command(
+    ctx: typer.Context,
+    num_exps: NumExperimentsAnnotation = 0,
+    file_output: FileOutputAnnotation = True,
+    steal_slurm: StealSlurmAnnotation = False,
+    post_mortem: PostMortemAnnotation = False,
+    output_to_console: OutputToConsoleAnnotation = False,
+    worker_gpus: WorkerGPUsAnnotation = None,
+    worker_cpus: WorkerCPUsAnnotation = None,
+    worker_env: WorkerEnvAnnotation = None,
+    sacred_id: SacredIdAnnotation = None,
+    filter_dict: FilterDictAnnotation = None,
+    batch_id: BatchIdAnnotation = None,
+):
+    """
+    Launch a local worker that runs PENDING jobs.
+    """
+    assert ctx.obj['collection'], "Collection name must be passed to this command."
+    start_experiments(
+        ctx.obj['collection'],
+        local=True,
+        sacred_id=sacred_id,
+        batch_id=batch_id,
+        filter_dict=filter_dict,
+        num_exps=num_exps,
+        post_mortem=post_mortem,
+        output_to_console=output_to_console,
+        no_file_output=not file_output,
+        steal_slurm=steal_slurm,
+        no_worker=False,
+        set_to_pending=False,
+        worker_gpus=worker_gpus,
+        worker_cpus=worker_cpus,
+        worker_environment_vars=worker_env,
+    )
+
+
+
+@app.command("print-fail-trace")
+def print_traces_command(
+    ctx: typer.Context,
+    sacred_id: SacredIdAnnotation = None,
+    filter_dict: FilterDictAnnotation = None,
+    batch_id: BatchIdAnnotation = None,
+    filter_states: FilterStatesAnnotation = [*States.FAILED, *States.KILLED, *States.INTERRUPTED],
+    yes: YesAnnotation = False,
+):
+    """
+    Prints fail traces of all failed experiments.
+    """
+    assert ctx.obj['collection'], "Collection name must be passed to this command."
+    print_fail_trace(
+        ctx.obj['collection'],
+        sacred_id=sacred_id,
+        filter_states=filter_states,
+        batch_id=batch_id,
+        filter_dict=filter_dict,
+        yes=yes
+    )
+
+
+@app.command("reload-sources")
+def reload_sources_command(
+    ctx: typer.Context,
+    keep_old: Annotated[
+        bool,
+        typer.Option(
+            '-k',
+            '-keep-old',
+            help="Keep the old source files in the database.",
+        ),
+    ] = False,
+    batch_ids: Annotated[list[int], typer.Option(
+        '-b',
+        '--batch-ids',
+        help="Batch IDs (batch_id in the database collection) of the experiments. "
+                "Experiments that were staged together have the same batch_id.",
+    )] = None,
+    yes: YesAnnotation = False,
+):
+    """
+    Reload stashed source files.
+    """
+    assert ctx.obj['collection'], "Collection name must be passed to this command."
+    reload_sources(
+        ctx.obj['collection'],
+        batch_ids=batch_ids,
+        keep_old=keep_old,
+        yes=yes
+    )
+
+
+@app.command("print_command")
+def print_command_command(
+    ctx: typer.Context,
+    sacred_id: SacredIdAnnotation = None,
+    filter_dict: FilterDictAnnotation = None,
+    batch_id: BatchIdAnnotation = None,
+    num_exps: NumExperimentsAnnotation = 0,
+    worker_gpus: WorkerGPUsAnnotation = None,
+    worker_cpus: WorkerCPUsAnnotation = None,
+    worker_env: WorkerEnvAnnotation = None,
+):
+    """
+    Print the commands that would be executed by `start`.
+    """
+    print_command(
+        ctx.obj['collection'],
+        sacred_id=sacred_id,
+        batch_id=batch_id,
+        filter_dict=filter_dict,
+        num_exps=num_exps,
+        worker_gpus=worker_gpus,
+        worker_cpus=worker_cpus,
+        worker_environment_vars=worker_env,
+    )
+
+
+
+@app.command("reset")
+def reset_command(
+    ctx: typer.Context,
+    sacred_id: SacredIdAnnotation = None,
+    filter_states: FilterStatesAnnotation = [*States.FAILED, *States.KILLED, *States.INTERRUPTED],
+    filter_dict: FilterDictAnnotation = None,
+    batch_id: BatchIdAnnotation = None,
+    yes: YesAnnotation = False,
+):
+    """
+    Reset the state of experiments by setting their state to STAGED and cleaning their database entry.
+    Does not cancel Slurm jobs.
+    """
+    assert ctx.obj['collection'], "Collection name must be passed to this command."
+    reset_experiments(
+        ctx.obj['collection'],
+        sacred_id=sacred_id,
+        filter_states=filter_states,
+        batch_id=batch_id,
+        filter_dict=filter_dict,
+        yes=yes
+    )
+
+
+@app.command("delete")
+def delete_command(
+    ctx: typer.Context,
+    sacred_id: SacredIdAnnotation = None,
+    filter_states: FilterStatesAnnotation = [*States.STAGED, *States.FAILED, *States.KILLED, *States.INTERRUPTED],
+    filter_dict: FilterDictAnnotation = None,
+    batch_id: BatchIdAnnotation = None,
+    yes: YesAnnotation = False,
+):
+    """
+    Delete experiments by ID or state (does not cancel Slurm jobs).
+    """
+    assert ctx.obj['collection'], "Collection name must be passed to this command."
+    delete_experiments(
+        ctx.obj['collection'],
+        sacred_id=sacred_id,
+        filter_states=filter_states,
+        batch_id=batch_id,
+        filter_dict=filter_dict,
+        yes=yes
+    )
+
+
+@app.command("detect-killed")
+def detect_killed_command(
+    ctx: typer.Context,
+):
+    """
+    Detect experiments where the corresponding Slurm jobs were killed externally.
+    """
+    assert ctx.obj['collection'], "Collection name must be passed to this command."
+    detect_killed(ctx.obj['collection'])
+
+
+@app.command("status")
+def status_command(
+    ctx: typer.Context,
+):
+    """
+    Report status of experiments in the database collection.
+    """
+    assert ctx.obj['collection'], "Collection name must be passed to this command."
+    report_status(ctx.obj['collection'])
+
+
+@functools.lru_cache()
+def command_names(app: typer.Typer) -> set[str]:
+    return {
+        cmd.name if cmd.name else cmd.callback.__name__
+        for cmd in app.registered_commands
+    }
+
+
+def split_args(commands):
     # Divide argv by commands
     split_argv = [[]]
     for c in sys.argv[1:]:
-        if c in commands.choices:
+        if c in commands:
             split_argv.append([c])
         else:
             split_argv[-1].append(c)
-    # Parse only the top-level commands if there are no subcommands
-    # We need to do this to ensure seml --help is working
     if len(split_argv) == 1:
-        argcomplete.autocomplete(parser)
-        parser.parse_args(split_argv[0])
-    # Parse all subcommands
-    commands = []
-    shared_args = split_argv[0]
-    if len(shared_args) == 0:
-        # Add empty collection if not provided
-        shared_args = ['']
-    for argv in split_argv[1:]:
-        # Copy the original arguments and the command specific ones
-        n = parser.parse_args(shared_args + argv)
-        commands.append(n)
-    return commands
-
-
-class ParameterAction(argparse.Action):
-    def __init__(self, option_strings, dest, **kwargs):
-        super().__init__(option_strings, dest, **kwargs)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, {
-            value.split('=')[0]: eval('='.join(value.split('=')[1:]))
-            for value in values
-        })
+        return split_argv
+    shared = split_argv[0]
+    chained_commands = split_argv[1:]
+    # If none of the shared args contains a collection
+    # name, we add the default collection name.
+    if all(arg.startswith('-') for arg in shared):
+        shared.append('')
+    # Combine commands with the shared arguments
+    result = []
+    for split in chained_commands:
+        result.append(shared + split)
+    return result
 
 
 def main():
-    parser = argparse.ArgumentParser(
-            description="Manage experiments for the given configuration. "
-                        "Each experiment is represented as a record in the database. "
-                        "See examples/README.md for more details.",
-            formatter_class=argparse.RawTextHelpFormatter,
-            add_help=True)
-    parser.set_defaults(func=parser.print_usage)
-    parser.add_argument(
-            'db_collection_name', type=str, nargs='?', default=None,
-            help="Name of the database collection for the experiment.").completer = DbCollectionCompleter
-    parser.add_argument(
-            '--verbose', '-v', action='store_true',
-            help='Display more log messages.')
-
-    subparsers = parser.add_subparsers(title="Possible operations")
-    
-    parser_list_db = subparsers.add_parser(
-            "list",
-            help="Lists all collections in the database.")
-    parser_list_db.add_argument(
-            "pattern",
-            nargs="?",
-            help="A regex that must match the collections to print", type=str,
-            default=r'.*',
-    )
-    parser_list_db.add_argument(
-            "--progress-bar",
-            help="Whether to print a progress bar for iterating over collections", action='store_true', dest="progress"
-    )
-    parser_list_db.set_defaults(func=list_database)
-
-    parser_clean_db = subparsers.add_parser(
-            "clean-db",
-            help="Remove orphaned artifacts in the DB from runs which have been deleted.")
-    parser_clean_db.set_defaults(func=clean_unreferenced_artifacts)
-
-    parser_jupyter = subparsers.add_parser(
-            "jupyter",
-            help="Start a Jupyter slurm job. Uses SBATCH options defined in settings.py under "
-                 "SBATCH_OPTIONS_TEMPLATES.JUPYTER")
-    parser_jupyter.add_argument(
-            "-l", "--lab", action='store_true',
-            help="Start a jupyter-lab instance instead of jupyter notebook.")
-    parser_jupyter.add_argument(
-            "-c", "--conda-env", type=str, default=None,
-            help="Start the Jupyter instance in a Conda environment.")
-    parser_jupyter.add_argument(
-            '-sb', '--sbatch-options', type=json.loads,
-            help="Dictionary (passed as a string, e.g. '{\"gres\": \"gpu:2\"}') to request two GPUs.")
-    parser_jupyter.set_defaults(func=start_jupyter_job)
-
-    parser_configure = subparsers.add_parser(
-            "configure",
-            help="Configure SEML (database, argument completion, ...).")
-    parser_configure.add_argument(
-            "--all", action='store_true', help="Configure all SEML settings"
-    )
-    parser_configure.add_argument(
-            "--mongodb", action="store_true", help="Configure MongoDB settings"
-    )
-    parser_configure.add_argument(
-            "--argcomplete", action='store_true', help="Configure settings for argument completion"
-    )
-    parser_configure.set_defaults(func=configure)
-
-    parser_add = subparsers.add_parser(
-            "add",
-            help="Add the experiments to the database as defined in the configuration.")
-    parser_add.add_argument(
-            'config_files', type=str, nargs='+',
-            help="Path to the YAML configuration file for the experiment.").completer = FilesCompleter
-    parser_add.add_argument(
-            '-nh', '--no-hash', action='store_true',
-            help="Do not use the hash of the config dictionary to filter out duplicates (by comparing all "
-                 "dictionary values individually). This is much slower, so use only if you have a good reason not to "
-                 "use the hash.")
-    parser_add.add_argument(
-            '-nsc', '--no-sanity-check', action='store_true',
-            help="Do not check the config for missing/unused arguments. "
-                 "Use this if the check fails unexpectedly when using "
-                 "advanced Sacred features or to accelerate adding.")
-    parser_add.add_argument(
-            '-ncc', '--no-code-checkpoint', action='store_true',
-            help="Do not save the source code files in the MongoDB. "
-                 "When a staged experiment is started, it will instead use the current version of the code "
-                 "files (which might have been updated in the meantime or could fail when started).")
-    parser_add.add_argument(
-            '-f', '--force-duplicates', action='store_true',
-            help="Add experiments to the database even when experiments with identical configurations "
-                 "are already in the database.")
-    parser_add.add_argument(
-            '-o', '--overwrite-params', action=ParameterAction, nargs='+', default={},
-            help="Specifies parameters that overwrite their respective values in all configs."
-                 "Format: <param>=<value>, use flat dictionary notation with key1.key2=value."
-    )
-    parser_add.set_defaults(func=add_config_files)
-
-    parser_start = subparsers.add_parser(
-            "start",
-            help="Fetch staged experiments from the database and run them (by default via Slurm).")
-    parser_start.add_argument(
-            '-d', '--debug', action='store_true',
-            help="Run a single interactive experiment without Sacred observers and with post-mortem debugging. "
-                 "Implies `--verbose --num-exps 1 --post-mortem --output-to-console`.")
-    parser_start.add_argument(
-            '-ds', '--debug-server', action='store_true',
-            help="Run the experiment with a debug server, to which you can remotely connect with e.g. VS Code. "
-                 "Implies `--debug`.")
-    parser_start_local = parser_start.add_argument_group("optional arguments for local jobs")
-    parser_start_local.add_argument(
-            '-l', '--local', action='store_true',
-            help="Run the experiments locally (not via Slurm).")
-    parser_start_local.add_argument(
-            '-nw', '--no-worker', action='store_true',
-            help="Do not launch a local worker after setting experiments' state to PENDING.")
-    parser_start.set_defaults(func=start_experiments, set_to_pending=True)
-
-    parser_print_fail_trace = subparsers.add_parser(
-            "print-fail-trace",
-            help="Prints fail traces of all failed experiments."
-    )
-    parser_print_fail_trace.add_argument(
-            '-s', '--filter-states', type=str, nargs='*', default=[*States.FAILED, *States.KILLED,
-                                                                   *States.INTERRUPTED],
-            help="List of states to filter experiments by. "
-                 "Prints traces of all experiments if an empty list is passed. "
-                 "Default: Print failed, killed and interrupted experiments.")
-    parser_print_fail_trace.set_defaults(func=print_fail_trace)
-
-
-    parser_reload = subparsers.add_parser(
-            "reload-sources",
-            help="Reload uploaded source files."
-    )
-    parser_reload.add_argument(
-            '-k', '--keep-old', action='store_true',
-            help="Keeps the old source files in the database. (You will have to manually delete them or reload again.)"
-    )
-    parser_reload.add_argument(
-            '-b', '--batch-ids', type=int, default=None, nargs='*',
-            help="Batch IDs (batch_id in the database collection) of the experiments. "
-                 "Experiments that were staged together have the same batch_id."
-    )
-    parser_reload.set_defaults(func=reload_sources)
-
-    parser_launch_worker = subparsers.add_parser(
-        "launch-worker",
-        help="Launch a local worker that runs PENDING jobs.")
-    parser_launch_worker.set_defaults(func=start_experiments, set_to_pending=False, no_worker=False, local=True,
-                                      debug=False, debug_server=False)
-
-    parser_print_command = subparsers.add_parser(
-        "print-command",
-        help="Print the commands for running the experiments.")
-    parser_print_command.set_defaults(func=print_command)
-
-    for subparser in [parser_start, parser_launch_worker, parser_print_command]:
-        subparser.add_argument(
-                '-n', '--num-exps', type=int, default=0,
-                help="Only start the specified number of experiments. 0: run all (staged) experiments.")
-
-    for subparser in [parser_start, parser_launch_worker]:
-        subparser.add_argument(
-                '-nf', '--no-file-output', action='store_true',
-                help="Do not save the console output in a file.")
-
-    for subparser in [parser_start_local, parser_launch_worker]:
-        subparser.add_argument(
-                '-ss', '--steal-slurm', action='store_true',
-                help="Local jobs 'steal' from the Slurm queue, "
-                     "i.e. also execute experiments waiting for execution via Slurm.")
-        subparser.add_argument(
-                '-pm', '--post-mortem', action='store_true',
-                help="Activate post-mortem debugging with pdb.")
-        subparser.add_argument(
-                '-o', '--output-to-console', action='store_true',
-                help="Print output to console.")
-
-    for subparser in [parser_start_local, parser_launch_worker, parser_print_command]:
-        subparser.add_argument(
-                '-wg', '--worker-gpus', type=str,
-                help="The IDs of the GPUs used by the local worker. Will be directly passed to CUDA_VISIBLE_DEVICES.")
-        subparser.add_argument(
-                '-wc', '--worker-cpus', type=int,
-                help="The number of CPU cores used by the local worker. Will be directly passed to OMP_NUM_THREADS.")
-        subparser.add_argument(
-                '-we', '--worker-environment-vars', type=json.loads,
-                help="Further environment variables to be set for the local worker.")
-
-    parser_status = subparsers.add_parser(
-            "status",
-            help="Report status of experiments in the database collection.")
-    parser_status.set_defaults(func=report_status)
-
-    parser_cancel = subparsers.add_parser(
-            "cancel",
-            help="Cancel the Slurm job/job step corresponding to experiments, filtered by ID or state.")
-    parser_cancel.add_argument(
-            '-s', '--filter-states', type=str, nargs='*', default=[*States.PENDING, *States.RUNNING],
-            help="List of states to filter experiments by. Cancels all experiments if an empty list is passed. "
-                 "Default: Cancel all pending and running experiments.")
-    parser_cancel.set_defaults(func=cancel_experiments)
-
-    parser_delete = subparsers.add_parser(
-            "delete",
-            help="Delete experiments by ID or state (does not cancel Slurm jobs).")
-    parser_delete.add_argument(
-            '-s', '--filter-states', type=str, nargs='*', default=[*States.STAGED, *States.FAILED,
-                                                                   *States.KILLED, *States.INTERRUPTED],
-            help="List of states to filter experiments by. Deletes all experiments if an empty list is passed. "
-                 "Default: Delete all staged, failed, killed and interrupted experiments.")
-    parser_delete.set_defaults(func=delete_experiments)
-
-    parser_reset = subparsers.add_parser(
-            "reset",
-            help="Reset the state of experiments by setting their state to staged and cleaning their database entry. "
-                 "Does not cancel Slurm jobs.")
-    parser_reset.add_argument(
-            '-s', '--filter-states', type=str, nargs='*', default=[*States.FAILED, *States.KILLED,
-                                                                   *States.INTERRUPTED],
-            help="List of states to filter experiments by. "
-                 "Resets all experiments if an empty list is passed. "
-                 "Default: Reset failed, killed and interrupted experiments.")
-    parser_reset.set_defaults(func=reset_experiments)
-
-    parser_detect = subparsers.add_parser(
-            "detect-killed",
-            help="Detect experiments where the corresponding Slurm jobs were killed externally.")
-    parser_detect.set_defaults(func=detect_killed)
-
-    for subparser in [parser_start, parser_launch_worker, parser_print_command,
-                      parser_cancel, parser_delete, parser_reset, parser_print_fail_trace]:
-        subparser.add_argument(
-                '-id', '--sacred-id', type=int,
-                help="Sacred ID (_id in the database collection) of the experiment. "
-                     "Takes precedence over other filters.")
-        subparser.add_argument(
-                '-f', '--filter-dict', type=json.loads,
-                help="Dictionary (passed as a string, e.g. '{\"config.dataset\": \"cora_ml\"}') to filter "
-                     "the experiments by.")
-        subparser.add_argument(
-                '-b', '--batch-id', type=int,
-                help="Batch ID (batch_id in the database collection) of the experiments. "
-                     "Experiments that were staged together have the same batch_id.")
-    
-    for subparser in [parser_cancel, parser_reload, parser_clean_db, parser_delete, parser_reset]:
-        subparser.add_argument(
-            '-y', '--yes', action='store_true',
-            help="Automatically confirm all dialogues with yes."
-        )
-    commands = parse_args(parser, subparsers)
-
-    # Initialize logging
-    hdlr = logging.StreamHandler(sys.stderr)
-    hdlr.setFormatter(LoggingFormatter())
-    logging.root.addHandler(hdlr)
-    
-    for command in commands:
-        # Set logging level
-        if command.verbose:
-            logging_level = logging.VERBOSE
-        else:
-            logging_level = logging.INFO
-        logging.root.setLevel(logging_level)
-        if command.func in [configure, start_jupyter_job, list_database, parser.print_usage]:
-            # No collection name required
-            del command.db_collection_name
-        elif command.func in [clean_unreferenced_artifacts]:
-            # Here the db_collection_name **can** be passed but does not have to.
-            pass
-        elif not command.db_collection_name:
-            parser.error("the following arguments are required: db_collection_name")
-
-        f = command.func
-        # If we chain commands we should wait until jobs are properly cancelled
-        if f == cancel_experiments and len(commands) > 1:
-            command.wait = True
-        del command.func
-        del command.verbose
-        if 'filter_states' in command:
-            command.filter_states = [state.upper() for state in command.filter_states]
-        f(**vars(command))
+    # We have to split the arguments manually to get proper chaining.
+    # If we were to use typer built-in chaining, lists would end the chain.
+    for args in split_args(command_names(app)):
+        # The app will typically exit after running once.
+        # We want to run it multiple times, so we catch the SystemExit exception.
+        try:
+            app(args)
+        except SystemExit as e:
+            if e.code == 0:
+                continue
+            else:
+                raise e
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "tqdm>=4.36",
     "debugpy>=1.2.1",
     "requests>=2.28.1",
-    "argcomplete",
+    "typer>=0.9, <1.0"
 ]
 
 with open("README.md", "r") as fh:
@@ -34,6 +34,9 @@ setup(
             ]
     },
     install_requires=install_requires,
+    extras_require={
+        "pretty": ["rich<14.0"],
+    },
     python_requires='>=3.8',
     zip_safe=False,
 )


### PR DESCRIPTION
# Reimplementation of the CLI with `typer`

## Rationale
* The `agparse`-based CLI became quite large and unreadable.
* `typer` offers automatic documentation, see `docs.md`
* `typer` offers autocompletion which is faster (based on my very subjective feeling)
  * In my experience, the autocompletion Is now reasonably usable without to long wait times
* `typer` offers a better formatted CLI experience

## Further inclusions
* Prompts are now handled via `typer.promp`, i.e., reprompted if the answer is unclear
* If `rich` is installed, printing is visually more pleasing, e.g.,
  * `seml --help`:
     |without| `rich` |
     | --- | ---|
     | <img width="598" alt="image" src="https://github.com/TUM-DAML/seml/assets/9084670/afc145f9-6874-4493-9bb8-c83cd1af1891"> | <img width="600" alt="image" src="https://github.com/TUM-DAML/seml/assets/9084670/4a37ab07-a7f4-42a7-9439-9ef2159f7ec5">|

  * `seml collection status`
     |without| `rich` |
     | --- | ---|
     | <img width="487" alt="image" src="https://github.com/TUM-DAML/seml/assets/9084670/e595bbc5-83c7-4b19-9dbc-f7d680e4b8e2"> | <img width="379" alt="image" src="https://github.com/TUM-DAML/seml/assets/9084670/22d08db5-a1fd-4d85-962b-75598d7189f8">|

* Since not everyone might like the new printing style, it is optional and printing defaults to the old printing if `rich` is not installed. To install `rich` with `seml`: `pip install seml[pretty]`.


## Concerns
* The CLI changed slightly, for instance `seml collection delete -s pending staged` is now `seml collection delete -s "pending staged"` or `seml collection delete -s pending -s staged`.
* We now have more code since I explicitly wrapped each function, alternatively we could also adapt a short hand notation as before we directly pass all `locals()`.
* Having two different visuals for printing could be confusing?
* Are we sure that all parameters are translated correctly?