### PR TITLE
Add sacred.Experiment subclass

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -35,6 +35,7 @@ $ seml [OPTIONS] COLLECTION COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
 * `list`: Lists all collections in the database.
 * `print-command`: Print the commands that would be executed...
 * `print-fail-trace`: Prints fail traces of all failed experiments.
+* `print-output`: Print the output of experiments.
 * `reload-sources`: Reload stashed source files.
 * `reset`: Reset the state of experiments by setting...
 * `start`: Fetch staged experiments from the database...
@@ -353,6 +354,24 @@ $ seml print-fail-trace [OPTIONS]
 * `-b, --batch-id INTEGER`: Batch ID (batch_id in the database collection) of the experiments. Experiments that were staged together have the same batch_id.
 * `-s, --filter-states [STAGED|QUEUED|PENDING|RUNNING|FAILED|KILLED|INTERRUPTED|COMPLETED]`: List of states to filter the experiments by. If empty (""), all states are considered.  [default: FAILED, KILLED, INTERRUPTED]
 * `-p, --projection KEY`: List of configuration keys, e.g., `config.model`, to additionally print.
+* `--help`: Show this message and exit.
+
+## `seml print-output`
+
+Print the output of experiments.
+
+**Usage**:
+
+```console
+$ seml print-output [OPTIONS]
+```
+
+**Options**:
+
+* `-id, --sacred-id INTEGER`: Sacred ID (_id in the database collection) of the experiment. Takes precedence over other filters.
+* `-s, --filter-states [STAGED|QUEUED|PENDING|RUNNING|FAILED|KILLED|INTERRUPTED|COMPLETED]`: List of states to filter the experiments by. If empty (""), all states are considered.  [default: RUNNING, FAILED, KILLED, INTERRUPTED, COMPLETED]
+* `-f, --filter-dict JSON`: Dictionary (passed as a string, e.g. '{"config.dataset": "cora_ml"}') to filter the experiments by.
+* `-b, --batch-id INTEGER`: Batch ID (batch_id in the database collection) of the experiments. Experiments that were staged together have the same batch_id.
 * `--help`: Show this message and exit.
 
 ## `seml reload-sources`

--- a/examples/advanced_example_experiment.py
+++ b/examples/advanced_example_experiment.py
@@ -5,18 +5,11 @@ We wrap all the experiment-specific functionality inside the "ExperimentWrapper"
 are parsed by a specific method. This avoids having one large "main" function which takes all parameters as input.
 """
 
-from sacred import Experiment
 import numpy as np
-import seml
+from seml.experiment import Experiment
 
 
 ex = Experiment()
-seml.setup_logger(ex)
-
-
-@ex.post_run_hook
-def collect_stats(_run):
-    seml.collect_exp_stats(_run)
 
 
 # Named configs can be used to define subconfigurations in a modular way. They can be composed in the experiment's configuration yaml file.
@@ -54,12 +47,6 @@ def no_batchnorm():
 
 @ex.config
 def config():
-    overwrite = None
-    db_collection = None
-    if db_collection is not None:
-        ex.observers.append(
-            seml.create_mongodb_observer(db_collection, overwrite=overwrite)
-        )
     name = "${config.model.model_type}_${config.data.dataset}"
 
 

--- a/examples/example_experiment.py
+++ b/examples/example_experiment.py
@@ -1,15 +1,9 @@
 import logging
 import numpy as np
-import seml
+from seml.experiment import Experiment
 
 
-ex = seml.Experiment()
-seml.setup_logger(ex)
-
-
-@ex.post_run_hook
-def collect_stats(_run):
-    seml.collect_exp_stats(_run)
+ex = Experiment()
 
 
 @ex.automain

--- a/examples/example_experiment.py
+++ b/examples/example_experiment.py
@@ -1,26 +1,15 @@
 import logging
-from sacred import Experiment
 import numpy as np
 import seml
 
 
-ex = Experiment()
+ex = seml.Experiment()
 seml.setup_logger(ex)
 
 
 @ex.post_run_hook
 def collect_stats(_run):
     seml.collect_exp_stats(_run)
-
-
-@ex.config
-def config():
-    overwrite = None
-    db_collection = None
-    if db_collection is not None:
-        ex.observers.append(
-            seml.create_mongodb_observer(db_collection, overwrite=overwrite)
-        )
 
 
 @ex.automain

--- a/src/seml/__init__.py
+++ b/src/seml/__init__.py
@@ -2,6 +2,7 @@ import importlib.metadata
 from seml.experiment import *  # noqa
 from seml.observers import *  # noqa
 from seml.evaluation import *  # noqa
+from seml.experiment import Experiment  # noqa
 
 
 __version__ = importlib.metadata.version(__package__ or __name__)

--- a/src/seml/__init__.py
+++ b/src/seml/__init__.py
@@ -1,8 +1,6 @@
 import importlib.metadata
-from seml.experiment import *  # noqa
 from seml.observers import *  # noqa
 from seml.evaluation import *  # noqa
-from seml.experiment import Experiment  # noqa
 
 
 __version__ = importlib.metadata.version(__package__ or __name__)

--- a/src/seml/__init__.py
+++ b/src/seml/__init__.py
@@ -4,8 +4,15 @@ from seml.evaluation import *  # noqa
 
 
 def setup_logger(ex, level='INFO'):
+    import logging
     from seml.experiment import setup_logger
 
+    logging.warn(
+        'Importing setup_logger directly from seml is deprecated.\n'
+        'Use from seml.experiment import setup_logger instead.\n'
+        'Note that seml.experiment.Experiment already includes the logger setup.\n'
+        'See https://github.com/TUM-DAML/seml/blob/master/examples/example_experiment.py'
+    )
     setup_logger(ex, level=level)
 
 

--- a/src/seml/__init__.py
+++ b/src/seml/__init__.py
@@ -3,4 +3,30 @@ from seml.observers import *  # noqa
 from seml.evaluation import *  # noqa
 
 
+def setup_logger(ex, level='INFO'):
+    import logging
+    from seml.experiment import setup_logger
+
+    logging.warn(
+        'seml.setup_logger is deprecated.\n'
+        'Use seml.experiment.Experiment instead of sacred.Experiment.\n'
+        'seml.experiment.Experiment already includes the logger setup.\n'
+        'See https://github.com/TUM-DAML/seml/blob/master/examples/example_experiment.py'
+    )
+    setup_logger(ex, level=level)
+
+
+def collect_exp_stats(run):
+    import logging
+    from seml.experiment import collect_exp_stats
+
+    logging.warn(
+        'seml.collect_exp_stats is deprecated.\n'
+        'Use seml.experiment.Experiment instead of sacred.Experiment.\n'
+        'seml.experiment.Experiment already includes the statistics collection.\n'
+        'See https://github.com/TUM-DAML/seml/blob/master/examples/example_experiment.py'
+    )
+    collect_exp_stats(run)
+
+
 __version__ = importlib.metadata.version(__package__ or __name__)

--- a/src/seml/__init__.py
+++ b/src/seml/__init__.py
@@ -4,28 +4,14 @@ from seml.evaluation import *  # noqa
 
 
 def setup_logger(ex, level='INFO'):
-    import logging
     from seml.experiment import setup_logger
 
-    logging.warn(
-        'seml.setup_logger is deprecated.\n'
-        'Use seml.experiment.Experiment instead of sacred.Experiment.\n'
-        'seml.experiment.Experiment already includes the logger setup.\n'
-        'See https://github.com/TUM-DAML/seml/blob/master/examples/example_experiment.py'
-    )
     setup_logger(ex, level=level)
 
 
 def collect_exp_stats(run):
-    import logging
     from seml.experiment import collect_exp_stats
 
-    logging.warn(
-        'seml.collect_exp_stats is deprecated.\n'
-        'Use seml.experiment.Experiment instead of sacred.Experiment.\n'
-        'seml.experiment.Experiment already includes the statistics collection.\n'
-        'See https://github.com/TUM-DAML/seml/blob/master/examples/example_experiment.py'
-    )
     collect_exp_stats(run)
 
 

--- a/src/seml/__main__.py
+++ b/src/seml/__main__.py
@@ -429,9 +429,8 @@ def cancel_command(
     """
     Cancel the Slurm job/job step corresponding to experiments, filtered by ID or state.
     """
-    wait = (
-        wait
-        or len(
+    wait |= (
+        len(
             [
                 a
                 for a in sys.argv

--- a/src/seml/__main__.py
+++ b/src/seml/__main__.py
@@ -30,6 +30,7 @@ from seml.manage import (
     list_database,
     print_duplicates,
     print_fail_trace,
+    print_output,
     print_status,
     reload_sources,
     reset_experiments,
@@ -760,6 +761,31 @@ def print_command_command(
         worker_environment_vars=worker_env,
         unresolved=unresolved,
         resolve_interpolations=not no_interpolation,
+    )
+
+
+@app.command('print-output')
+@restrict_collection()
+def print_output_command(
+    ctx: typer.Context,
+    sacred_id: SacredIdAnnotation = None,
+    filter_states: FilterStatesAnnotation = States.RUNNING
+    + States.FAILED
+    + States.KILLED
+    + States.INTERRUPTED
+    + States.COMPLETED,
+    filter_dict: FilterDictAnnotation = None,
+    batch_id: BatchIdAnnotation = None,
+):
+    """
+    Print the output of experiments.
+    """
+    print_output(
+        ctx.obj['collection'],
+        sacred_id=sacred_id,
+        filter_states=filter_states,
+        batch_id=batch_id,
+        filter_dict=filter_dict,
     )
 
 

--- a/src/seml/config.py
+++ b/src/seml/config.py
@@ -337,23 +337,23 @@ def generate_named_config(named_config_dict: Dict) -> List[str]:
     # Parse named config names and priorities
     names, priorities = {}, {}
     for k, v in named_config_dict.items():
-        if k.startswith(SETTINGS.NAMED_CONFIG_PREFIX):
+        if k.startswith(SETTINGS.NAMED_CONFIG.PREFIX):
             if isinstance(v, str):
                 v = dict(name=str(v))
             if not isinstance(v, Dict):
                 raise ConfigError(
                     f'Named configs must be given as '
-                    f'{SETTINGS.NAMED_CONFIG_PREFIX}{"{identifier}"}: str | '
+                    f'{SETTINGS.NAMED_CONFIG.PREFIX}{"{identifier}"}: str | '
                     '{"name": str, "priority": int}'
                 )
             for attribute, value in v.items():
-                if attribute == SETTINGS.NAMED_CONFIG_KEY_NAME:
+                if attribute == SETTINGS.NAMED_CONFIG.KEY_NAME:
                     if not isinstance(value, str):
                         raise ConfigError(
                             f'Named config names should be strings, not {value} ({value.__class__})'
                         )
                     names[k] = value
-                elif attribute == SETTINGS.NAMED_CONFIG_KEY_PRIORITY:
+                elif attribute == SETTINGS.NAMED_CONFIG.KEY_PRIORITY:
                     try:
                         value = int(value)
                     except (ValueError, TypeError):
@@ -363,7 +363,7 @@ def generate_named_config(named_config_dict: Dict) -> List[str]:
                     priorities[k] = value
                 else:
                     raise ConfigError(
-                        f'Named configs only have the attributes {[SETTINGS.NAMED_CONFIG_KEY_NAME, SETTINGS.NAMED_CONFIG_KEY_PRIORITY]}'
+                        f'Named configs only have the attributes {[SETTINGS.NAMED_CONFIG.KEY_NAME, SETTINGS.NAMED_CONFIG.KEY_PRIORITY]}'
                     )
     for idx in priorities:
         if idx not in names:
@@ -400,7 +400,7 @@ def generate_named_configs(configs: List[Dict]) -> Tuple[List[Dict], List[List[s
             {
                 k: v
                 for k, v in config.items()
-                if not k.startswith(SETTINGS.NAMED_CONFIG_PREFIX)
+                if not k.startswith(SETTINGS.NAMED_CONFIG.PREFIX)
             }
         )
         result_named_configs.append(generate_named_config(config))

--- a/src/seml/config.py
+++ b/src/seml/config.py
@@ -540,12 +540,15 @@ def resolve_configs(
         Resolved configurations
     """
     import sacred
+    from seml.experiment import Experiment
 
     exp_module = import_exe(executable, conda_env, working_dir)
 
     # Extract experiment from module
     exps = [
-        v for k, v in exp_module.__dict__.items() if isinstance(v, sacred.Experiment)
+        v
+        for k, v in exp_module.__dict__.items()
+        if isinstance(v, (sacred.Experiment, Experiment))
     ]
     if len(exps) == 0:
         raise ExecutableError(
@@ -557,6 +560,13 @@ def resolve_configs(
             f"Can't resolve configs."
         )
     exp = exps[0]
+    if not isinstance(exp, Experiment):
+        logging.warn(
+            'The use of sacred.Experiemnt is deprecated. Please use seml.experiment.Experiment instead.\n'
+            'seml.experiment.Experiment already includes typical MongoDB observer and logging setups.\n'
+            'Please familiar yourself with the new API and adjust your code accordingly.\n'
+            'See https://github.com/TUM-DAML/seml/blob/master/examples/example_experiment.py'
+        )
     with working_directory(working_dir):
         return _sacred_create_configs(exp, configs, named_configs)
 

--- a/src/seml/description.py
+++ b/src/seml/description.py
@@ -83,7 +83,7 @@ def collection_set_description(
 
     if (
         not yes
-        and num_to_overwrite >= SETTINGS.CONFIRM_DESCRIPTION_UPDATE_THRESHOLD
+        and num_to_overwrite >= SETTINGS.CONFIRM_THRESHOLD.DESCRIPTION_UPDATE
         and not prompt(
             f'{num_to_overwrite} experiment(s) have a different description. Proceed?',
             type=bool,
@@ -141,7 +141,7 @@ def collection_delete_description(
     ]
     if (
         not yes
-        and len(exps) >= SETTINGS.CONFIRM_DESCRIPTION_DELETE_THRESHOLD
+        and len(exps) >= SETTINGS.CONFIRM_THRESHOLD.DESCRIPTION_DELETE
         and not prompt(
             f'Deleting descriptions of {len(exps)} experiment(s). Proceed?', type=bool
         )

--- a/src/seml/experiment.py
+++ b/src/seml/experiment.py
@@ -35,7 +35,7 @@ class Experiment(ExperimentBase):
         additional_cli_options: Optional[Sequence[CLIOption]] = None,
         save_git_info: bool = True,
         add_mongodb_observer: bool = True,
-        setup_logger: bool = True,
+        setup_default_logger: bool = True,
         capture_output: bool | None = None,
         collect_stats: bool = True,
     ):
@@ -51,10 +51,10 @@ class Experiment(ExperimentBase):
         self.capture_output = capture_output
         if add_mongodb_observer:
             self.configurations.append(MongoDbObserverConfig(self))
-        if setup_logger:
+        if setup_default_logger:
             setup_logger(self)
         if collect_stats:
-            self.post_run_hook(collect_exp_stats)
+            self.post_run_hook(lambda _run: collect_exp_stats(_run))
 
     def run(
         self,

--- a/src/seml/experiment.py
+++ b/src/seml/experiment.py
@@ -35,6 +35,9 @@ class Experiment(ExperimentBase):
         additional_cli_options: Optional[Sequence[CLIOption]] = None,
         save_git_info: bool = True,
         add_mongodb_observer: bool = True,
+        setup_logger: bool = True,
+        capture_output: bool | None = None,
+        collect_stats: bool = True,
     ):
         super().__init__(
             name=name,
@@ -45,8 +48,13 @@ class Experiment(ExperimentBase):
             additional_cli_options=additional_cli_options,
             save_git_info=save_git_info,
         )
+        self.capture_output = capture_output
         if add_mongodb_observer:
             self.configurations.append(MongoDbObserverConfig(self))
+        if setup_logger:
+            setup_logger(self)
+        if collect_stats:
+            self.post_run_hook(collect_exp_stats)
 
     def run(
         self,
@@ -57,7 +65,7 @@ class Experiment(ExperimentBase):
         meta_info: Optional[dict] = None,
         options: Optional[dict] = None,
     ):
-        if not SETTINGS.EXPERIMENT.CAPTURE_OUTPUT:
+        if not SETTINGS.EXPERIMENT.CAPTURE_OUTPUT and not self.capture_output:
             SACRED_SETTINGS.CAPTURE_MODE = 'no'
         super().run(
             command_name=command_name,

--- a/src/seml/experiment.py
+++ b/src/seml/experiment.py
@@ -3,7 +3,7 @@ from enum import Enum
 import logging
 import resource
 import sys
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Union
 
 from sacred import SETTINGS as SACRED_SETTINGS
 from sacred import Experiment as ExperimentBase
@@ -42,8 +42,8 @@ class Experiment(ExperimentBase):
         additional_cli_options: Optional[Sequence[CLIOption]] = None,
         save_git_info: bool = True,
         add_mongodb_observer: bool = True,
-        logger: LoggerOptions | str | None = LoggerOptions.RICH,
-        capture_output: bool | None = None,
+        logger: Optional[Union[LoggerOptions, str]] = LoggerOptions.RICH,
+        capture_output: Optional[bool] = None,
         collect_stats: bool = True,
     ):
         super().__init__(

--- a/src/seml/experiment.py
+++ b/src/seml/experiment.py
@@ -59,7 +59,7 @@ class Experiment(ExperimentBase):
         if add_mongodb_observer:
             self.configurations.append(MongoDbObserverConfig(self))
         if logger:
-            _setup_logger(self, LoggerOptions(logger))
+            setup_logger(self, LoggerOptions(logger))
         if collect_stats:
             self.post_run_hook(lambda _run: _collect_exp_stats(_run))
 
@@ -108,7 +108,7 @@ class MongoDbObserverConfig:
         return config_summary
 
 
-def _setup_logger(
+def setup_logger(
     ex: ExperimentBase, logger_option: LoggerOptions = LoggerOptions.RICH, level='INFO'
 ):
     """
@@ -126,6 +126,13 @@ def _setup_logger(
     None
 
     """
+    if hasattr(ex, 'logger') and ex.logger:
+        logging.warn(
+            'Logger already set up for this experiment.\n'
+            'The new seml.experiment.Experiment class already includes the logger setup.\n'
+            'Either remove the explicit call to setup_logger or disable the logger setup in the Experiment constructor.'
+        )
+        return
     if logger_option is LoggerOptions.NONE:
         return
     logger = logging.getLogger()
@@ -214,16 +221,6 @@ def _collect_exp_stats(run):
 
     collection = get_collection(run.config['db_collection'])
     collection.update_one({'_id': exp_id}, {'$set': {'stats': stats}})
-
-
-def setup_logger(ex, level='INFO'):
-    logging.warn(
-        'seml.setup_logger is deprecated.\n'
-        'Use seml.experiment.Experiment instead of sacred.Experiment.\n'
-        'seml.experiment.Experiment already includes the logger setup.\n'
-        'See https://github.com/TUM-DAML/seml/blob/master/examples/example_experiment.py'
-    )
-    _setup_logger(ex, level=level)
 
 
 def collect_exp_stats(run):

--- a/src/seml/experiment.py
+++ b/src/seml/experiment.py
@@ -59,9 +59,9 @@ class Experiment(ExperimentBase):
         if add_mongodb_observer:
             self.configurations.append(MongoDbObserverConfig(self))
         if logger:
-            setup_logger(self, LoggerOptions(logger))
+            _setup_logger(self, LoggerOptions(logger))
         if collect_stats:
-            self.post_run_hook(lambda _run: collect_exp_stats(_run))
+            self.post_run_hook(lambda _run: _collect_exp_stats(_run))
 
     def run(
         self,
@@ -108,7 +108,7 @@ class MongoDbObserverConfig:
         return config_summary
 
 
-def setup_logger(
+def _setup_logger(
     ex: ExperimentBase, logger_option: LoggerOptions = LoggerOptions.RICH, level='INFO'
 ):
     """
@@ -145,7 +145,7 @@ def setup_logger(
     ex.logger = logger
 
 
-def collect_exp_stats(run):
+def _collect_exp_stats(run):
     """
     Collect information such as CPU user time, maximum memory usage,
     and maximum GPU memory usage and save it in the MongoDB.
@@ -214,3 +214,23 @@ def collect_exp_stats(run):
 
     collection = get_collection(run.config['db_collection'])
     collection.update_one({'_id': exp_id}, {'$set': {'stats': stats}})
+
+
+def setup_logger(ex, level='INFO'):
+    logging.warn(
+        'seml.setup_logger is deprecated.\n'
+        'Use seml.experiment.Experiment instead of sacred.Experiment.\n'
+        'seml.experiment.Experiment already includes the logger setup.\n'
+        'See https://github.com/TUM-DAML/seml/blob/master/examples/example_experiment.py'
+    )
+    _setup_logger(ex, level=level)
+
+
+def collect_exp_stats(run):
+    logging.warn(
+        'seml.collect_exp_stats is deprecated.\n'
+        'Use seml.experiment.Experiment instead of sacred.Experiment.\n'
+        'seml.experiment.Experiment already includes the statistics collection.\n'
+        'See https://github.com/TUM-DAML/seml/blob/master/examples/example_experiment.py'
+    )
+    _collect_exp_stats(run)

--- a/src/seml/experiment.py
+++ b/src/seml/experiment.py
@@ -109,7 +109,7 @@ class MongoDbObserverConfig:
 
 
 def setup_logger(
-    ex: ExperimentBase, logger: LoggerOptions = LoggerOptions.RICH, level='INFO'
+    ex: ExperimentBase, logger_option: LoggerOptions = LoggerOptions.RICH, level='INFO'
 ):
     """
     Set up logger for experiment.
@@ -128,11 +128,11 @@ def setup_logger(
     """
     logger = logging.getLogger()
     logger.handlers = []
-    if logger is LoggerOptions.RICH:
+    if logger_option is LoggerOptions.RICH:
         from rich.logging import RichHandler
 
         logger.addHandler(RichHandler(level, show_time=True, show_level=True))
-    elif logger is LoggerOptions.DEFAULT:
+    elif logger_option is LoggerOptions.DEFAULT:
         ch = logging.StreamHandler()
         formatter = logging.Formatter(
             fmt='%(asctime)s (%(levelname)s): %(message)s', datefmt='%Y-%m-%d %H:%M:%S'

--- a/src/seml/experiment.py
+++ b/src/seml/experiment.py
@@ -65,7 +65,9 @@ class Experiment(ExperimentBase):
         meta_info: Optional[dict] = None,
         options: Optional[dict] = None,
     ):
-        if not SETTINGS.EXPERIMENT.CAPTURE_OUTPUT and not self.capture_output:
+        if (
+            not SETTINGS.EXPERIMENT.CAPTURE_OUTPUT and not self.capture_output
+        ) or self.capture_output is False:
             SACRED_SETTINGS.CAPTURE_MODE = 'no'
         super().run(
             command_name=command_name,

--- a/src/seml/experiment.py
+++ b/src/seml/experiment.py
@@ -126,6 +126,8 @@ def setup_logger(
     None
 
     """
+    if logger_option is LoggerOptions.NONE:
+        return
     logger = logging.getLogger()
     logger.handlers = []
     if logger_option is LoggerOptions.RICH:

--- a/src/seml/manage.py
+++ b/src/seml/manage.py
@@ -1232,6 +1232,22 @@ def print_output(
     batch_id: Optional[int] = None,
     filter_dict: Optional[Dict] = None,
 ):
+    """
+    Prints the output of experiments
+
+    Parameters
+    ----------
+    db_collection_name : str
+        The collection to print the output of
+    sacred_id : Optional[int], optional
+        The ID of the experiment to print the output of, by default None
+    filter_states : Optional[List[str]], optional
+        Filter on experiment states, by default None
+    batch_id : Optional[int], optional
+        Filter on the batch ID of experiments, by default None
+    filter_dict : Optional[Dict], optional
+        Additional filters, by default None
+    """
     from seml.console import console, Heading
 
     filter_dict = build_filter_dict(

--- a/src/seml/manage.py
+++ b/src/seml/manage.py
@@ -187,7 +187,7 @@ def cancel_experiments(
             logging.error(f'No experiment found with ID {sacred_id}.')
 
         logging.info(f'Cancelling {ncancel} experiment{s_if(ncancel)}.')
-        if ncancel >= SETTINGS.CONFIRM_CANCEL_THRESHOLD:
+        if ncancel >= SETTINGS.CONFIRM_THRESHOLD.CANCEL:
             if not yes and not prompt('Are you sure? (y/n)', type=bool):
                 exit(1)
 
@@ -302,7 +302,7 @@ def delete_experiments(
     logging.info(
         f'Deleting {ndelete} configuration{s_if(ndelete)} from database collection.'
     )
-    if ndelete >= SETTINGS.CONFIRM_DELETE_THRESHOLD:
+    if ndelete >= SETTINGS.CONFIRM_THRESHOLD.DELETE:
         if not yes and not prompt('Are you sure? (y/n)', type=bool):
             exit(1)
 
@@ -473,7 +473,7 @@ def reset_experiments(
         raise MongoDBError(f'No experiment found with ID {sacred_id}.')
 
     logging.info(f'Resetting the state of {nreset} experiment{s_if(nreset)}.')
-    if nreset >= SETTINGS.CONFIRM_RESET_THRESHOLD:
+    if nreset >= SETTINGS.CONFIRM_THRESHOLD.RESET:
         if not yes and not prompt('Are you sure? (y/n)', type=bool):
             exit(1)
     for exp in exps:

--- a/src/seml/observers.py
+++ b/src/seml/observers.py
@@ -3,6 +3,7 @@ import os
 
 from seml.database import get_mongo_client, get_mongodb_config
 from seml.settings import SETTINGS
+from seml.utils import warn_multiple_calls
 
 __all__ = [
     'create_mongodb_observer',
@@ -14,6 +15,13 @@ __all__ = [
 ]
 
 
+@warn_multiple_calls(
+    'Created {num_calls} MongoDB observers.\n'
+    'This might not be intended.\n'
+    'seml.experiment.Experiment creates one by default.\n'
+    'Either disable the default observer (seml.experiment.Experiment(add_mongodb_observer=False)) \n'
+    'or remove the explicit call to create_mongodb_observer.'
+)
 def create_mongodb_observer(collection, mongodb_config=None, overwrite=None):
     """Create a MongoDB observer for a Sacred experiment
 

--- a/src/seml/settings.py
+++ b/src/seml/settings.py
@@ -123,14 +123,21 @@ SETTINGS = munchify(
             'seml.description',
             'config',
         ],  # in which fields to allow variable interpolation
-        'NAMED_CONFIG_PREFIX': '+',  # prefix for all named configuration parameters
-        'NAMED_CONFIG_KEY_NAME': 'name',  # key that identifies the name of a named config
-        'NAMED_CONFIG_KEY_PRIORITY': 'priority',  # key that identifies the priority of a named config
-        'CONFIRM_CANCEL_THRESHOLD': 10,
-        'CONFIRM_DELETE_THRESHOLD': 10,
-        'CONFIRM_RESET_THRESHOLD': 10,
-        'CONFIRM_DESCRIPTION_DELETE_THRESHOLD': 10,
-        'CONFIRM_DESCRIPTION_UPDATE_THRESHOLD': 10,
+        'NAMED_CONFIG': {
+            'PREFIX': '+',  # prefix for all named configuration parameters
+            'KEY_NAME': 'name',  # key that identifies the name of a named config
+            'KEY_PRIORITY': 'priority',  # key that identifies the priority of a named config
+        },
+        'CONFIRM_THRESHOLD': {
+            'DELETE': 10,
+            'RESET': 10,
+            'CANCEL': 10,
+            'DESCRIPTION_DELETE': 10,
+            'DESCRIPTION_UPDATE': 10,
+        },
+        'EXPERIMENT': {
+            'CAPTURE_OUTPUT': False,  # whether to capture the output of the experiment in the database
+        },
         'CONFIG_RESOLUTION_PROGRESS_BAR_THRESHOLD': 25,
         'AUTOCOMPLETE_CACHE_ALIVE_TIME': 300,
         'SETUP_COMMAND': '',

--- a/src/seml/start.py
+++ b/src/seml/start.py
@@ -77,14 +77,14 @@ def get_command_from_exp(
             config = {
                 k: v
                 for k, v in interpolated['config_unresolved'].items()
-                if not k.startswith(SETTINGS.NAMED_CONFIG_PREFIX)
+                if not k.startswith(SETTINGS.NAMED_CONFIG.PREFIX)
             }
             named_configs = interpolated[key_named_configs]
         else:
             config = {
                 k: v
                 for k, v in config_unresolved.items()
-                if not k.startswith(SETTINGS.NAMED_CONFIG_PREFIX)
+                if not k.startswith(SETTINGS.NAMED_CONFIG.PREFIX)
             }
     else:
         assert (

--- a/src/seml/utils.py
+++ b/src/seml/utils.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import json
 import logging
 import os
@@ -527,3 +528,34 @@ def to_hashable(x: Any) -> Any:
         return tuple(map(to_hashable, x))
     else:
         raise ValueError(f'{x} of type {type(x)} is not hashable.')
+
+
+T = TypeVar('T', bound=Callable)
+
+
+def warn_multiple_calls(warning: str, warn_after: int = 1):
+    """
+    Decorator to warn if a function is called multiple times.
+
+    Parameters
+    ----------
+    warning: str
+        The warning message.
+    warn_after: int
+        The number of calls after which to warn.
+    """
+
+    def decorator(f: T) -> T:
+        num_calls = 0
+
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            nonlocal num_calls
+            num_calls += 1
+            if num_calls > warn_after:
+                logging.warning(warning.format(num_calls=num_calls))
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
Here, we group a bunch of standard configurations into a custom Experiment class, which must be used going forward.
This PR has the following breaking changes:
* `seml.experiment.py`'s content is no longer imported by default
* `seml.experiment.Experiment` must be used going forward instead of `sacred.Experiment`
* Some settings were reorganized.
* `seml` will not capture the output of experiments within the MongoDB anymore. To turn this behavior on, either edit your `~/config/seml/settings.py` or create the experiment with `Experiment(capture_output=True)`.

This PR also adds the `print-output` command that pulls the output of the experiment from the slurm log file. If that is not present, it attempts to pull it from the database.