### PR TITLE
VSCode clickable URL to attach debugger

### DIFF
--- a/src/seml/start.py
+++ b/src/seml/start.py
@@ -125,10 +125,15 @@ def get_command_from_exp(
                 f"Starting debug server with IP '{ip_address}' and port '{port}'. "
                 f'Experiment will wait for a debug client to attach.'
             )
-            logging.info(
-                "If you are using VSCode, you can use the 'Debug Launcher' extension to attach: "
-                f'{_generate_debug_attach_url(ip_address, port)}'
-            )
+            previous_root = logging.root
+            try:
+                logging.basicConfig(force=True, level=logging.INFO)
+                logging.info(
+                    "If you are using VSCode, you can use the 'Debug Launcher' extension to attach: \n"
+                    f'{_generate_debug_attach_url(ip_address, port)}'
+                )
+            finally:
+                logging.root = previous_root
         interpreter = (
             f'python -m debugpy --listen {ip_address}:{port} --wait-for-client'
         )

--- a/src/seml/start.py
+++ b/src/seml/start.py
@@ -951,7 +951,7 @@ def print_command(
 ):
     import rich
 
-    from seml.console import Heading, console
+    from seml.console import console, Heading
 
     collection = get_collection(db_collection_name)
 

--- a/src/seml/start.py
+++ b/src/seml/start.py
@@ -14,7 +14,6 @@ from typing import Dict, List, Optional
 
 from seml.config import generate_named_configs
 from seml.config import resolve_interpolations as resolve_config_interpolations
-from seml.console import console
 from seml.database import build_filter_dict, get_collection
 from seml.errors import ArgumentError, ConfigError, MongoDBError
 from seml.json import PythonEncoder
@@ -120,6 +119,8 @@ def get_command_from_exp(
         config_strings.append('--debug')
 
     if debug_server:
+        from seml.console import console
+
         ip_address, port = find_free_port()
         if print_info:
             logging.info(
@@ -129,7 +130,7 @@ def get_command_from_exp(
             attach_link = _generate_debug_attach_url(ip_address, port)
 
             logging.info(
-                "If you are using VSCode, you can use the 'Debug Launcher' extension to attach: \n"
+                "If you are using VSCode, you can use the 'Debug Launcher' extension to attach:"
             )
             console.out(attach_link)
 
@@ -951,7 +952,7 @@ def print_command(
 ):
     import rich
 
-    from seml.console import console, Heading
+    from seml.console import Heading, console
 
     collection = get_collection(db_collection_name)
 

--- a/src/seml/start.py
+++ b/src/seml/start.py
@@ -49,6 +49,8 @@ def get_command_from_exp(
     unresolved=False,
     resolve_interpolations: bool = True,
 ):
+    from seml.console import console
+
     if 'executable' not in exp['seml']:
         raise MongoDBError(
             f"No executable found for experiment {exp['_id']}. Aborting."
@@ -119,8 +121,6 @@ def get_command_from_exp(
         config_strings.append('--debug')
 
     if debug_server:
-        from seml.console import console
-
         ip_address, port = find_free_port()
         if print_info:
             logging.info(
@@ -402,31 +402,33 @@ def start_srun_job(
     -------
     None
     """
+    from seml.console import pause_live_widget
 
-    # Construct srun options string
-    # srun will run 2 processes in parallel when ntasks is not specified. Probably because of hyperthreading.
-    if 'ntasks' not in srun_options:
-        srun_options['ntasks'] = 1
-    srun_options_str = create_slurm_options_string(srun_options, True)
+    with pause_live_widget():
+        # Construct srun options string
+        # srun will run 2 processes in parallel when ntasks is not specified. Probably because of hyperthreading.
+        if 'ntasks' not in srun_options:
+            srun_options['ntasks'] = 1
+        srun_options_str = create_slurm_options_string(srun_options, True)
 
-    if not unobserved:
-        collection.update_one(
-            {'_id': exp['_id']}, {'$set': {'slurm.sbatch_options': srun_options}}
-        )
+        if not unobserved:
+            collection.update_one(
+                {'_id': exp['_id']}, {'$set': {'slurm.sbatch_options': srun_options}}
+            )
 
-    # Set command args for job inside Slurm
-    cmd_args = f"--local --sacred-id {exp['_id']} "
-    cmd_args += ' '.join(seml_arguments)
+        # Set command args for job inside Slurm
+        cmd_args = f"--local --sacred-id {exp['_id']} "
+        cmd_args += ' '.join(seml_arguments)
 
-    cmd = f'srun{srun_options_str} seml {collection.name} start {cmd_args}'
-    try:
-        subprocess.run(cmd, shell=True, check=True)
-    except subprocess.CalledProcessError as e:
-        logging.error(
-            f"Could not start Slurm job via srun. Here's the sbatch error message:\n"
-            f"{e.stderr.decode('utf-8')}"
-        )
-        exit(1)
+        cmd = f'srun{srun_options_str} seml {collection.name} start {cmd_args}'
+        try:
+            subprocess.run(cmd, shell=True, check=True)
+        except subprocess.CalledProcessError as e:
+            logging.error(
+                f"Could not start Slurm job via srun. Here's the sbatch error message:\n"
+                f"{e.stderr.decode('utf-8')}"
+            )
+            exit(1)
 
 
 def start_local_job(
@@ -839,6 +841,8 @@ def start_local_worker(
     """
     from rich.progress import Progress
 
+    from seml.console import pause_live_widget
+
     check_compute_node()
 
     if 'SLURM_JOBID' in os.environ:
@@ -876,65 +880,69 @@ def start_local_worker(
 
     exp_query.update(filter_dict)
 
-    with Progress(auto_refresh=False) as progress:
-        task = progress.add_task('Running experiments...', total=None)
-        while collection.count_documents(exp_query) > 0 and jobs_counter < num_exps:
-            if unobserved:
-                exp = collection.find_one(exp_query)
-            else:
-                exp = collection.find_one_and_update(
-                    exp_query, {'$set': {'status': States.RUNNING[0]}}
+    with pause_live_widget():
+        with Progress(auto_refresh=False) as progress:
+            task = progress.add_task('Running experiments...', total=None)
+            while collection.count_documents(exp_query) > 0 and jobs_counter < num_exps:
+                if unobserved:
+                    exp = collection.find_one(exp_query)
+                else:
+                    exp = collection.find_one_and_update(
+                        exp_query, {'$set': {'status': States.RUNNING[0]}}
+                    )
+                if exp is None:
+                    continue
+                if 'array_id' in exp['slurm']:
+                    # Clean up MongoDB entry
+                    slurm_ids = {
+                        'array_id': exp['slurm']['array_id'],
+                        'task_id': exp['slurm']['task_id'],
+                    }
+                    reset_slurm_dict(exp)
+                    collection.replace_one({'_id': exp['_id']}, exp, upsert=False)
+
+                    # Cancel Slurm job; after cleaning up to prevent race conditions
+                    cancel_experiment_by_id(
+                        collection,
+                        exp['_id'],
+                        set_interrupted=False,
+                        slurm_dict=slurm_ids,
+                    )
+
+                progress.console.print(
+                    f"current id : {exp['_id']}, failed={num_exceptions}/{jobs_counter} experiments"
                 )
-            if exp is None:
-                continue
-            if 'array_id' in exp['slurm']:
-                # Clean up MongoDB entry
-                slurm_ids = {
-                    'array_id': exp['slurm']['array_id'],
-                    'task_id': exp['slurm']['task_id'],
-                }
-                reset_slurm_dict(exp)
-                collection.replace_one({'_id': exp['_id']}, exp, upsert=False)
 
-                # Cancel Slurm job; after cleaning up to prevent race conditions
-                cancel_experiment_by_id(
-                    collection, exp['_id'], set_interrupted=False, slurm_dict=slurm_ids
-                )
+                # Add newline if we need to avoid tqdm's output
+                if (
+                    debug_server
+                    or output_to_console
+                    or logging.root.level <= logging.VERBOSE
+                ):
+                    print(file=sys.stderr)
 
-            progress.console.print(
-                f"current id : {exp['_id']}, failed={num_exceptions}/{jobs_counter} experiments"
-            )
-
-            # Add newline if we need to avoid tqdm's output
-            if (
-                debug_server
-                or output_to_console
-                or logging.root.level <= logging.VERBOSE
-            ):
-                print(file=sys.stderr)
-
-            if output_to_file:
-                output_dir_path = get_output_dir_path(exp)
-            else:
-                output_dir_path = None
-            try:
-                success = start_local_job(
-                    collection=collection,
-                    exp=exp,
-                    unobserved=unobserved,
-                    post_mortem=post_mortem,
-                    output_dir_path=output_dir_path,
-                    output_to_console=output_to_console,
-                    debug_server=debug_server,
-                )
-                if success is False:
-                    num_exceptions += 1
-            except KeyboardInterrupt:
-                logging.info('Caught KeyboardInterrupt signal. Aborting.')
-                exit(1)
-            jobs_counter += 1
-            progress.advance(task)
-            # tq.set_postfix(current_id=exp['_id'], failed=f"{num_exceptions}/{jobs_counter} experiments")
+                if output_to_file:
+                    output_dir_path = get_output_dir_path(exp)
+                else:
+                    output_dir_path = None
+                try:
+                    success = start_local_job(
+                        collection=collection,
+                        exp=exp,
+                        unobserved=unobserved,
+                        post_mortem=post_mortem,
+                        output_dir_path=output_dir_path,
+                        output_to_console=output_to_console,
+                        debug_server=debug_server,
+                    )
+                    if success is False:
+                        num_exceptions += 1
+                except KeyboardInterrupt:
+                    logging.info('Caught KeyboardInterrupt signal. Aborting.')
+                    exit(1)
+                jobs_counter += 1
+                progress.advance(task)
+                # tq.set_postfix(current_id=exp['_id'], failed=f"{num_exceptions}/{jobs_counter} experiments")
 
 
 def print_command(

--- a/src/seml/start.py
+++ b/src/seml/start.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import logging
 import os
 import shlex
@@ -6,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import time
+import urllib
 import uuid
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -123,6 +125,10 @@ def get_command_from_exp(
                 f"Starting debug server with IP '{ip_address}' and port '{port}'. "
                 f'Experiment will wait for a debug client to attach.'
             )
+            logging.info(
+                "If you are using VSCode, you can use the 'Debug Launcher' extension to attach: "
+                f'{_generate_debug_attach_url(ip_address, port)}'
+            )
         interpreter = (
             f'python -m debugpy --listen {ip_address}:{port} --wait-for-client'
         )
@@ -130,6 +136,17 @@ def get_command_from_exp(
         interpreter = 'python'
 
     return interpreter, exe, config_strings
+
+
+def _generate_debug_attach_url(ip_address, port):
+    launch_config = {
+        'type': 'debugpy',
+        'request': 'attach',
+        'connect': {'host': ip_address, 'port': port},
+        'pathMappings': [{'localRoot': '${workspaceFolder}', 'remoteRoot': '.'}],
+    }
+    launch_config = urllib.parse.quote(json.dumps(launch_config))
+    return f'vscode://fabiospampinato.vscode-debug-launcher/launch?args={launch_config}'
 
 
 def get_config_overrides(config):

--- a/src/seml/start.py
+++ b/src/seml/start.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional
 
 from seml.config import generate_named_configs
 from seml.config import resolve_interpolations as resolve_config_interpolations
+from seml.console import console
 from seml.database import build_filter_dict, get_collection
 from seml.errors import ArgumentError, ConfigError, MongoDBError
 from seml.json import PythonEncoder
@@ -125,15 +126,13 @@ def get_command_from_exp(
                 f"Starting debug server with IP '{ip_address}' and port '{port}'. "
                 f'Experiment will wait for a debug client to attach.'
             )
-            previous_root = logging.root
-            try:
-                logging.basicConfig(force=True, level=logging.INFO)
-                logging.info(
-                    "If you are using VSCode, you can use the 'Debug Launcher' extension to attach: \n"
-                    f'{_generate_debug_attach_url(ip_address, port)}'
-                )
-            finally:
-                logging.root = previous_root
+            attach_link = _generate_debug_attach_url(ip_address, port)
+
+            logging.info(
+                "If you are using VSCode, you can use the 'Debug Launcher' extension to attach: \n"
+            )
+            console.out(attach_link)
+
         interpreter = (
             f'python -m debugpy --listen {ip_address}:{port} --wait-for-client'
         )


### PR DESCRIPTION
Added a log message containing a clickable URL to automatically attach a debugger in VSCode. No need to create a launch config every time.

### Reference issue
No issue.


### What does this implement/fix?
If running `seml [collection] start --debug-server`, previously, the IP and port have just been printed to the console.
To attach the debugger in VSCode one had to create a launch configuration every time.

Using the VSCode extension [Debug Launcher](https://marketplace.visualstudio.com/items?itemName=fabiospampinato.vscode-debug-launcher) one can create clickable URLs for launch configs.
This PR adds a generator for such a URL and prints it to the console.

![debug_url_seml](https://github.com/TUM-DAML/seml/assets/90392376/93e0c7ab-ea83-43dd-b511-d4ba114938e5)


### Additional information
I had to hack the logger in order to prevent line breaks due to the limited console width. 
This is **very** unpretty.
If there is a better way, let me know.

- [x] I updated the docs via typer-cli with `_SEML_COMPLETE=1 typer seml.__main__ utils docs --name seml --output docs.md` or did not change the CLI.
