### PR TITLE
Always use environment variables from add time + minor changes

### DIFF
--- a/examples/example_config.yaml
+++ b/examples/example_config.yaml
@@ -60,18 +60,25 @@ seml:
   description: An example configuration.
 
 slurm:
+  - experiments_per_job: 1
+    sbatch_options:
+      gres: gpu:0
+      mem: 1G
+      cpus-per-task: 1
+      time: 0-08:00
+      partition: cpu_all,cpu_large
   - experiments_per_job: 4
     sbatch_options:
       gres: gpu:1 # num GPUs
-      mem: 16G # memory
-      cpus-per-task: 2 # num cores
+      mem: 1G # memory
+      cpus-per-task: 1 # num cores
       time: 0-08:00 # max time, D-HH:MM
       partition: gpu_gtx1080
   - experiments_per_job: 16
     sbatch_options:
       gres: gpu:1 # num GPUs
-      mem: 16G # memory
-      cpus-per-task: 2 # num cores
+      mem: 1G # memory
+      cpus-per-task: 1 # num cores
       time: 0-08:00 # max time, D-HH:MM
       partition: gpu_a100
 

--- a/src/seml/commands/add.py
+++ b/src/seml/commands/add.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import datetime
 import logging
 import os
 from typing import TYPE_CHECKING, Any, Dict, cast
@@ -16,6 +15,7 @@ from seml.experiment.config import (
     read_config,
     remove_duplicates,
     remove_prepended_dashes,
+    requires_interpolation,
     resolve_configs,
     resolve_interpolations,
 )
@@ -29,6 +29,7 @@ from seml.utils import (
     remove_keys_from_nested,
     to_typeddict,
     unflatten,
+    utcnow,
 )
 from seml.utils.errors import ConfigError
 
@@ -125,7 +126,7 @@ def add_configs(
                 **{
                     '_id': start_id + idx,
                     'status': States.STAGED[0],
-                    'add_time': datetime.datetime.utcnow(),
+                    'add_time': utcnow(),
                 },
             },
         )
@@ -134,11 +135,13 @@ def add_configs(
     if description is not None:
         for db_dict in documents:
             db_dict['seml']['description'] = description
-    if resolve_descriptions:
-        for db_dict in documents:
-            if 'description' in db_dict['seml']:
+        # If description is not supplied via CLI, it will already be resolved.
+        if resolve_descriptions and requires_interpolation(
+            {'description': description}, ['description']
+        ):
+            for db_dict in documents:
                 db_dict['seml']['description'] = resolve_description(
-                    db_dict['seml']['description'], db_dict
+                    db_dict['seml'].get('description', ''), db_dict
                 )
 
     collection.insert_many(documents)
@@ -324,7 +327,6 @@ def add_config_file(
                     }
                 ),
                 'config_unresolved': config_unresolved,
-                'seml': seml_config,
             },
         )
         for config, config_unresolved in zip(configs, configs_unresolved)

--- a/src/seml/document.py
+++ b/src/seml/document.py
@@ -73,6 +73,8 @@ class SemlDoc(SemlDocBase, total=False):
         The CLI command with unresolved named configurations that runs the experiment.
     temp_dir: str
         The temporary directory which has been used to restore source files from the DB.
+    env: dict[str, str]
+        The environment variables that were used to run the experiment.
     """
 
     output_file: str
@@ -83,6 +85,7 @@ class SemlDoc(SemlDocBase, total=False):
     command: str | None
     command_unresolved: str | None
     temp_dir: str | None
+    env: dict[str, str] | None
 
 
 class SemlConfig(SemlDoc, total=False):


### PR DESCRIPTION
Functionality change:
* Environment variables will now be stored in the MongoDB at add time and used when submitting a job. This allows you to dispatch jobs from a different environment than the one you used for adding.

Logging changes:
* We now display the correct number of files we deleted and do not count duplicates.
* We don't throw random exceptions when a job cannot claim an experiment but fail gracefully.

Performance changes:
* We use regex to figure out matches for interpolation keys (`seml add` is quite a bit faster)
* We avoid resolving the description twice (faster `seml add`)
* deleting files from the MongoDB is now running in parallel (`seml delete` is now pretty much instant)
