### PR TITLE
Fixes an IndexError when using a debug server without staged experiments

### DIFF
--- a/src/seml/commands/start.py
+++ b/src/seml/commands/start.py
@@ -897,7 +897,7 @@ def start_experiments(
         num_exps=num_exps,
         set_to_pending=set_to_pending and local,
     )
-    
+
     if not staged_experiments:
         logging.info('No experiments to run.')
         return

--- a/src/seml/commands/start.py
+++ b/src/seml/commands/start.py
@@ -898,7 +898,7 @@ def start_experiments(
         set_to_pending=set_to_pending and local,
     )
 
-    if debug_server:
+    if debug_server and staged_experiments:
         use_stored_sources = 'source_files' in staged_experiments[0]['seml']
         if use_stored_sources:
             raise ArgumentError(

--- a/src/seml/commands/start.py
+++ b/src/seml/commands/start.py
@@ -897,8 +897,11 @@ def start_experiments(
         num_exps=num_exps,
         set_to_pending=set_to_pending and local,
     )
-
-    if debug_server and staged_experiments:
+    
+    if not staged_experiments:
+        logging.info('No experiments to run.')
+        return
+    if debug_server:
         use_stored_sources = 'source_files' in staged_experiments[0]['seml']
         if use_stored_sources:
             raise ArgumentError(


### PR DESCRIPTION
### What does this implement/fix?
Previously, running `seml experiment start --debug-server` threw an IndexError when no experiments were staged. Running `seml experiment start` just printed an info warning. This PR aligns the two behaviors.