### PR TITLE
Tigru/fix/experiments killing each other

### DIFF
--- a/src/seml/commands/manage.py
+++ b/src/seml/commands/manage.py
@@ -93,6 +93,8 @@ def cancel_empty_pending_jobs(db_collection_name: str, *sacred_ids: int):
             {'execution'},
         )
     )
+
+    # We exclude all SLURM jobs that are needed for continuing a RESCHEDULED experiment
     rescheduled_ids = []
     for exp in rescheduled_exps:
         execution = exp['execution']
@@ -672,7 +674,7 @@ def detect_killed(db_collection_name: str, print_detected: bool = True):
     cluster = get_cluster_name()
     exps = collection.find(
         {
-            'status': {'$in': [*States.PENDING, *States.RUNNING]},
+            'status': {'$in': [*States.PENDING, *States.RUNNING, *States.RESCHEDULED]},
             'execution.cluster': cluster,  # only check experiments that are running on the current cluster
             # Previously we only checked for started experiments by including the following line:
             # 'host': {'$exists': True},  # only check experiments that have been started

--- a/src/seml/commands/start.py
+++ b/src/seml/commands/start.py
@@ -1133,6 +1133,8 @@ def claim_experiment(db_collection_name: str, exp_ids: Sequence[int]):
             'execution.task_id': task_id,
             'execution.cluster': cluster_name,
         }
+        # First, we check whether this SLURM job is responsible for a RESCHEDULED experiment
+        # If so, we claim this first
         exp = collection.find_one_and_update(
             {
                 '_id': {'$in': list(exp_ids)},
@@ -1144,6 +1146,8 @@ def claim_experiment(db_collection_name: str, exp_ids: Sequence[int]):
             {'$set': {'status': States.RUNNING[0], **update}},
             {'_id': 1, 'slurm': 1},
         )
+        # Only after we have checked that this job is not responsible for a RESCHEDULED experiment
+        # can we pick up a pending one.
         if exp is None:
             exp = collection.find_one_and_update(
                 {

--- a/src/seml/commands/start.py
+++ b/src/seml/commands/start.py
@@ -1123,6 +1123,7 @@ def claim_experiment(db_collection_name: str, exp_ids: Sequence[int]):
     """
     collection = get_collection(db_collection_name)
     array_id, task_id = get_current_slurm_array_id()
+    exp = None
     if array_id is not None and task_id is not None:
         # We are running in slurm
         array_id, task_id = int(array_id), int(task_id)
@@ -1135,11 +1136,23 @@ def claim_experiment(db_collection_name: str, exp_ids: Sequence[int]):
         exp = collection.find_one_and_update(
             {
                 '_id': {'$in': list(exp_ids)},
-                'status': {'$in': States.PENDING + States.RESCHEDULED},
+                'status': {'$in': States.RESCHEDULED},
+                'execution.array_id': array_id,
+                'execution.task_id': task_id,
+                'execution.cluster': cluster_name,
             },
             {'$set': {'status': States.RUNNING[0], **update}},
             {'_id': 1, 'slurm': 1},
         )
+        if exp is None:
+            exp = collection.find_one_and_update(
+                {
+                    '_id': {'$in': list(exp_ids)},
+                    'status': {'$in': States.PENDING},
+                },
+                {'$set': {'status': States.RUNNING[0], **update}},
+                {'_id': 1, 'slurm': 1},
+            )
         if exp is None:
             exit(3)
         # Set slurm output file


### PR DESCRIPTION
1 ) clean_experiments killed jobs that were requeued.
2 ) jobs in state RESCHEDULED could be picked up by any job and not the one responsible for the requeuing