### PR TITLE
Add explicitly listed artifacts to sources

### DIFF
--- a/examples/advanced_example_config.yaml
+++ b/examples/advanced_example_config.yaml
@@ -61,6 +61,8 @@ seml:
   description: "An advanced example configuration. We can also use variable interpolation here: ${config.model.model_type}"
   reschedule_timeout: 300 # The time (in seconds) that are left on the job before SEML will try to reschedule unfinished experiments.
   # Note that you have to implement a `reschedule_hook` to use this feature.
+  additional_artifacts:
+    - artifacts/something
 
 slurm:
   - experiments_per_job: 1

--- a/examples/advanced_example_experiment.py
+++ b/examples/advanced_example_experiment.py
@@ -5,6 +5,8 @@ We wrap all the experiment-specific functionality inside the "ExperimentWrapper"
 are parsed by a specific method. This avoids having one large "main" function which takes all parameters as input.
 """
 
+import logging
+
 import numpy as np
 from seml import Experiment
 
@@ -132,6 +134,11 @@ class ExperimentWrapper:
     def init_augmentation(self, flip: bool):
         self.augmentation_parameters = (flip,)
 
+    def init_artifacts(self):
+        # Load token from artifact specified in `seml.additional_artifacts
+        with open("artifacts/something") as f:
+            logging.info(f"Loaded artifact {f.read().strip()}")
+
     def init_all(self):
         """
         Sequentially run the sub-initializers of the experiment.
@@ -141,6 +148,7 @@ class ExperimentWrapper:
         self.init_optimizer()
         self.init_preprocessing()
         self.init_augmentation()
+        self.init_artifacts()
 
     @ex.capture(prefix="training")
     def train(self, patience, num_epochs):

--- a/examples/artifacts/something
+++ b/examples/artifacts/something
@@ -1,0 +1,1 @@
+<file content of the artifact>

--- a/src/seml/document.py
+++ b/src/seml/document.py
@@ -41,6 +41,7 @@ class SemlDocBase(TypedDict, total=False):
     name: str
     stash_all_py_files: bool
     reschedule_timeout: int | None
+    additional_artifacts: list[str]
 
 
 class SemlFileConfig(SemlDocBase, total=False):

--- a/src/seml/settings.py
+++ b/src/seml/settings.py
@@ -237,6 +237,7 @@ SETTINGS = cast(
                 'description',
                 'stash_all_py_files',
                 'reschedule_timeout',
+                'additional_artifacts',
             ],
             'SEML_CONFIG_VALUE_VERSION': 'version',
             'VALID_SLURM_CONFIG_VALUES': [

--- a/src/seml/utils/__init__.py
+++ b/src/seml/utils/__init__.py
@@ -788,3 +788,14 @@ def drop_typeddict_difference(obj: TD1, cls: type[TD1], cls2: type[TD2]) -> TD2:
         if k in result:
             del result[k]
     return result  # type: ignore
+
+
+def recursively_list_files(path: Path | str) -> set[Path]:
+    """Recursively lists all (resolved) files in the directory."""
+    path = Path(path)
+    if path.expanduser().resolve().is_file():
+        return {path.expanduser().resolve()}
+    elif path.expanduser().resolve().is_dir():
+        return {p.expanduser().resolve() for p in path.rglob('*') if p.is_file()}
+    else:
+        raise ValueError(f'Path {path} is neither a file nor a directory.')

--- a/src/seml/utils/__init__.py
+++ b/src/seml/utils/__init__.py
@@ -791,7 +791,12 @@ def drop_typeddict_difference(obj: TD1, cls: type[TD1], cls2: type[TD2]) -> TD2:
 
 
 def recursively_list_files(path: Path | str) -> set[Path]:
-    """Recursively lists all (resolved) files in the directory."""
+    """Recursively lists all (resolved) files in the directory.
+
+    Also supports `glob` patterns.
+    """
+    if any(c in str(path) for c in '*?[]'):
+        return {p.expanduser() for p in Path().rglob(str(path))}
     path = Path(path)
     if path.expanduser().resolve().is_file():
         return {path.expanduser().resolve()}


### PR DESCRIPTION
### What does this implement/fix?
This PR enables explicitly listing files / folders in the experiment's `seml` configuration that will be uploaded to MongoDB. This can be used for all sort of artifacts that are relevant to run experiments but are not explicitly detected by source code discovery which only considers `.py` files.


### Additional information
- [x] I updated the docs via typer-cli with `_SEML_COMPLETE=1 typer seml.__main__ utils docs --name seml --output docs.md` or did not change the CLI.
