### PR TITLE
Changed `uuidgen` to `mktemp`

### DIFF
--- a/src/seml/templates/slurm/slurm_template.sh
+++ b/src/seml/templates/slurm/slurm_template.sh
@@ -49,7 +49,8 @@ for i in $(seq 1 {experiments_per_job}); do
 
     # Create directory for the source files in MongoDB
     if {with_sources}; then
-        tmpdir="{tmp_directory}/$(uuidgen)"  # unique temp dir based on UUID
+        tmpdir=$(mktemp -d -p "{tmp_directory}" seml_sources.XXXXXXXX) || {{
+            (>&2 echo "ERROR: Could not create temporary directory for source files under {tmp_directory}."); exit 1; }}
         # Prepend the temp dir and potential src paths to $PYTHONPATH so it will be used by python.
         # https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/
         exp_pypath="$tmpdir:$tmpdir/src:$PYTHONPATH"


### PR DESCRIPTION
In case `uuidgen` is not installed on a system, SEML previously ignored the failed command and used `/tmp` as the source file directory.
At the end of the script SEML then proceeded to delete everything in the `/tmp` directory -- not ideal!

I think switching to `mktemp` and crashing the SLURM job in case of non-zero exit of the directory creation should be safer.
