### PR TITLE
Fix/ssh forward gpu usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ dev = [
     "pyright>=1.1.407",
     "tuna>=0.5.11",
 ]
-ssh_forward = ["sshtunnel>=0.4.0", "filelock>=3.13.3", "paramiko>=3.0,<4.0"]
+
+[project.optional-dependencies]
+ssh-forward = ["sshtunnel>=0.4.0", "filelock>=3.13.3", "paramiko>=3.0,<4.0"]
 
 [project.urls]
 Homepage = "https://github.com/TUM-DAML/seml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "typing_extensions>=4.10; python_version < '3.13'",
     "typing_extensions>=4.12; python_version >= '3.13'",
     "deepdiff>=7.0.1",
+    "setuptools<81",
 ]
 
 [dependency-groups]

--- a/src/seml/utils/ssh_forward.py
+++ b/src/seml/utils/ssh_forward.py
@@ -22,111 +22,6 @@ States = SETTINGS.STATES
 _STOP_COMMAND = 'stop'
 
 
-def retried_and_locked_ssh_port_forward(
-    retries_max: int = SETTINGS.SSH_FORWARD.RETRIES_MAX,
-    retries_delay: int = SETTINGS.SSH_FORWARD.RETRIES_DELAY,
-    lock_file: str = SETTINGS.SSH_FORWARD.LOCK_FILE,
-    lock_timeout: int = SETTINGS.SSH_FORWARD.LOCK_TIMEOUT,
-    **ssh_config,
-):
-    """
-    Attempt to establish an SSH tunnel with retries and a lock file to avoid parallel tunnel establishment.
-
-    Parameters
-    ----------
-    retries_max: int
-        Maximum number of retries to establish the tunnel.
-    retries_delay: float
-        Initial delay for exponential backoff.
-    lock_file: str
-        Path to the lock file.
-    lock_timeout: int
-        Timeout for acquiring the lock.
-    ssh_config: dict
-        Configuration for the SSH tunnel.
-
-    Returns
-    -------
-    server: SSHTunnelForwarder
-        The SSH tunnel server.
-    """
-    import random
-
-    from filelock import FileLock, Timeout
-    from sshtunnel import BaseSSHTunnelForwarderError, SSHTunnelForwarder
-
-    delay = retries_delay
-    error = None
-    # disable SSH forward messages
-    logging.getLogger('paramiko.transport').disabled = True
-    for _ in range(retries_max):
-        try:
-            lock = FileLock(lock_file, mode=0o666, timeout=lock_timeout)
-            with lock:
-                server = SSHTunnelForwarder(**ssh_config)
-                server.start()
-                if not server.tunnel_is_up[server.local_bind_address]:
-                    raise BaseSSHTunnelForwarderError()
-                return server
-        except Timeout as e:
-            error = e
-            logging.warning(f'Failed to aquire lock for ssh tunnel {lock_file}')
-        except BaseSSHTunnelForwarderError as e:
-            error = e
-            logging.warning(f'Retry establishing ssh tunnel in {delay} s')
-            # Jittered exponential retry
-            time.sleep(delay)
-            delay *= 2
-            delay += random.uniform(0, 1)
-
-    logging.error(f'Failed to establish ssh tunnel: {error}')
-    exit(1)
-
-
-def _ssh_forward_process(connection: Connection, ssh_config: dict[str, Any]):
-    """
-    Establish an SSH tunnel in a separate process. The process periodically checks if the tunnel is still up and
-    restarts it if it is not.
-
-    Parameters
-    ----------
-    connection: Connection
-        Connection carrying commands from the parent process.
-    ssh_config: dict
-        Configuration for the SSH tunnel.
-    """
-    server = retried_and_locked_ssh_port_forward(**ssh_config)
-    # We need to bind to the same local addresses
-    server._local_binds = server.local_bind_addresses
-    connection.send((str(server.local_bind_host), int(server.local_bind_port)))
-
-    while True:
-        # check if we should end the process
-        try:
-            command = None
-            if connection.poll(SETTINGS.SSH_FORWARD.HEALTH_CHECK_INTERVAL):
-                command = connection.recv()
-
-            if command == _STOP_COMMAND:
-                server.stop()
-                break
-
-            # Check for tunnel health
-            server.check_tunnels()
-            if not server.tunnel_is_up[server.local_bind_address]:
-                logging.warning('SSH tunnel was closed unexpectedly. Restarting.')
-                server.restart()
-        except KeyboardInterrupt:
-            server.stop()
-            break
-        except EOFError:
-            server.stop()
-            break
-        except Exception as e:
-            logging.error(f'Error in SSH tunnel health check:\n{e}')
-            server.restart()
-
-
 def _remove_unix_socket(socket_address: str):
     with contextlib.suppress(FileNotFoundError, OSError):
         os.unlink(socket_address)
@@ -152,7 +47,7 @@ def _start_ssh_forward_subprocess(connect_timeout: float):
         [
             sys.executable,
             '-m',
-            'seml.utils.ssh_forward',
+            'seml.utils.ssh_tunnel_worker',
             '--worker',
             socket_address,
             authkey.hex(),
@@ -269,32 +164,6 @@ def _get_ssh_forward(ssh_config: dict[str, Any]):
     return _forwards[ssh_config]
 
 
-def _worker_main(socket_address: str, authkey_hex: str):
-    from multiprocessing.connection import Listener
-
-    try:
-        authkey = bytes.fromhex(authkey_hex)
-    except ValueError:
-        logging.error('Invalid SSH worker authkey payload.')
-        return 1
-
-    listener = Listener(socket_address, family='AF_UNIX', authkey=authkey)
-    connection: Connection | None = None
-    try:
-        connection = listener.accept()
-        ssh_config = connection.recv()
-        if not isinstance(ssh_config, dict):
-            logging.error('SSH worker expects the configuration payload to be a dict.')
-            return 1
-        _ssh_forward_process(connection, ssh_config)
-    finally:
-        if connection is not None:
-            connection.close()
-        listener.close()
-        _remove_unix_socket(socket_address)
-    return 0
-
-
 def get_forwarded_mongo_client(
     db_name: str, username: str, password: str, ssh_config: dict[str, Any], **kwargs
 ):
@@ -333,11 +202,3 @@ def get_forwarded_mongo_client(
         **kwargs,
     )
     return client
-
-
-if __name__ == '__main__':
-    if len(sys.argv) != 4 or sys.argv[1] != '--worker':
-        raise SystemExit(
-            'Usage: python -m seml.utils.ssh_forward --worker <socket_address> <authkey_hex>'
-        )
-    raise SystemExit(_worker_main(sys.argv[2], sys.argv[3]))

--- a/src/seml/utils/ssh_forward.py
+++ b/src/seml/utils/ssh_forward.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import atexit
+import contextlib
 import logging
+import os
+import secrets
+import subprocess
+import sys
 import time
+import uuid
 from typing import TYPE_CHECKING, Any
 
 from seml.document import ExperimentDoc
@@ -10,9 +16,10 @@ from seml.settings import SETTINGS
 from seml.utils import Hashabledict, assert_package_installed
 
 if TYPE_CHECKING:
-    import multiprocessing.connection
+    from multiprocessing.connection import Connection
 
 States = SETTINGS.STATES
+_STOP_COMMAND = 'stop'
 
 
 def retried_and_locked_ssh_port_forward(
@@ -63,10 +70,10 @@ def retried_and_locked_ssh_port_forward(
                 return server
         except Timeout as e:
             error = e
-            logging.warn(f'Failed to aquire lock for ssh tunnel {lock_file}')
+            logging.warning(f'Failed to aquire lock for ssh tunnel {lock_file}')
         except BaseSSHTunnelForwarderError as e:
             error = e
-            logging.warn(f'Retry establishing ssh tunnel in {delay} s')
+            logging.warning(f'Retry establishing ssh tunnel in {delay} s')
             # Jittered exponential retry
             time.sleep(delay)
             delay *= 2
@@ -76,31 +83,33 @@ def retried_and_locked_ssh_port_forward(
     exit(1)
 
 
-def _ssh_forward_process(
-    pipe: multiprocessing.connection.Connection, ssh_config: dict[str, Any]
-):
+def _ssh_forward_process(connection: Connection, ssh_config: dict[str, Any]):
     """
     Establish an SSH tunnel in a separate process. The process periodically checks if the tunnel is still up and
     restarts it if it is not.
 
     Parameters
     ----------
-    pipe: multiprocessing.communication.Connection
-        Pipe to communicate with the main process.
+    connection: Connection
+        Connection carrying commands from the parent process.
     ssh_config: dict
         Configuration for the SSH tunnel.
     """
     server = retried_and_locked_ssh_port_forward(**ssh_config)
     # We need to bind to the same local addresses
     server._local_binds = server.local_bind_addresses
-    pipe.send((server.local_bind_host, server.local_bind_port))
+    connection.send((str(server.local_bind_host), int(server.local_bind_port)))
+
     while True:
         # check if we should end the process
         try:
-            if pipe.poll(SETTINGS.SSH_FORWARD.HEALTH_CHECK_INTERVAL):
-                if pipe.closed or pipe.recv() == 'stop':
-                    server.stop()
-                    break
+            command = None
+            if connection.poll(SETTINGS.SSH_FORWARD.HEALTH_CHECK_INTERVAL):
+                command = connection.recv()
+
+            if command == _STOP_COMMAND:
+                server.stop()
+                break
 
             # Check for tunnel health
             server.check_tunnels()
@@ -116,13 +125,77 @@ def _ssh_forward_process(
         except Exception as e:
             logging.error(f'Error in SSH tunnel health check:\n{e}')
             server.restart()
-    pipe.close()
 
 
-# We want to reuse the same multiprocessing context for all SSH tunnels
-_mp_context = None
+def _remove_unix_socket(socket_address: str):
+    with contextlib.suppress(FileNotFoundError, OSError):
+        os.unlink(socket_address)
+
+
+def _connect_to_ssh_worker(socket_address: str, authkey: bytes, timeout: float):
+    from multiprocessing.connection import Client
+
+    deadline = time.monotonic() + max(timeout, 0)
+    while True:
+        try:
+            return Client(socket_address, family='AF_UNIX', authkey=authkey)
+        except (FileNotFoundError, ConnectionRefusedError, OSError):
+            if time.monotonic() >= deadline:
+                raise TimeoutError('Failed to connect to SSH forwarding worker.')
+            time.sleep(0.05)
+
+
+def _start_ssh_forward_subprocess(connect_timeout: float):
+    socket_address = f'/tmp/seml_ssh_forward_{uuid.uuid4().hex}.sock'
+    authkey = secrets.token_bytes(16)  # avoid other processes connecting to the socket
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            '-m',
+            'seml.utils.ssh_forward',
+            '--worker',
+            socket_address,
+            authkey.hex(),
+        ]
+    )
+
+    try:
+        connection = _connect_to_ssh_worker(socket_address, authkey, connect_timeout)
+    except Exception:
+        if proc.poll() is None:
+            proc.terminate()
+        _remove_unix_socket(socket_address)
+        raise
+    return proc, connection, socket_address
+
+
+def _close_ssh_forward_subprocess(
+    proc: subprocess.Popen[Any],
+    connection: Connection | None,
+    socket_address: str,
+):
+    try:
+        if proc.poll() is None and connection is not None:
+            try:
+                connection.send(_STOP_COMMAND)
+            except (BrokenPipeError, EOFError, OSError):
+                pass
+    finally:
+        if connection is not None:
+            try:
+                connection.close()
+            except OSError:
+                pass
+        if proc.poll() is None:
+            proc.terminate()
+        _remove_unix_socket(socket_address)
+
+
 # To establish only a single connection to a remote
 _forwards: dict[Hashabledict, tuple[str, int]] = {}
+_forward_processes: dict[
+    Hashabledict, tuple[subprocess.Popen[Any], Connection, str]
+] = {}
 
 
 def _get_ssh_forward(ssh_config: dict[str, Any]):
@@ -150,46 +223,76 @@ def _get_ssh_forward(ssh_config: dict[str, Any]):
         'filelock',
         'Opening ssh tunnel requires `filelock` (e.g. `pip install filelock`)',
     )
-    import multiprocessing as mp
 
-    global _forwards, _mp_context
+    global _forwards, _forward_processes
 
     ssh_config = Hashabledict(ssh_config)
     if ssh_config not in _forwards:
-        if _mp_context is None:
-            _mp_context = mp.get_context('forkserver')
-        main_pipe, forward_pipe = _mp_context.Pipe(True)
-        proc = _mp_context.Process(
-            target=_ssh_forward_process, args=(forward_pipe, ssh_config)
-        )
-        proc.start()
-
-        def try_close():
-            try:
-                if not main_pipe.closed:
-                    main_pipe.send('stop')
-                    main_pipe.close()
-            finally:
-                pass
-
-        # Send stop if we exit the program
-        atexit.register(try_close)
-
         # Compute the maximum time we should wait
         retries_max = ssh_config.get('retries_max', SETTINGS.SSH_FORWARD.RETRIES_MAX)
         retries_delay = ssh_config.get(
             'retries_delay', SETTINGS.SSH_FORWARD.RETRIES_DELAY
         )
         max_delay = 2 ** (retries_max + 1) * retries_delay
-
-        # check if the forward process has been established correctly
-        if main_pipe.poll(max_delay):
-            host, port = main_pipe.recv()
-            _forwards[ssh_config] = (str(host), int(port))
-        else:
-            logging.error('Failed to establish SSH tunnel.')
+        try:
+            proc, connection, socket_address = _start_ssh_forward_subprocess(max_delay)
+        except TimeoutError:
+            logging.error('Failed to connect to SSH tunnel worker.')
             exit(1)
+
+        # Send stop if we exit the program
+        atexit.register(
+            lambda: _close_ssh_forward_subprocess(proc, connection, socket_address)
+        )
+
+        try:
+            connection.send(dict(ssh_config))
+        except (BrokenPipeError, EOFError, OSError):
+            logging.error('Failed to send SSH tunnel configuration to worker.')
+            _close_ssh_forward_subprocess(proc, connection, socket_address)
+            exit(1)
+
+        if not connection.poll(max_delay):
+            logging.error('Failed to establish SSH tunnel.')
+            _close_ssh_forward_subprocess(proc, connection, socket_address)
+            exit(1)
+
+        try:
+            host, port = connection.recv()
+        except (EOFError, OSError, ValueError, TypeError) as e:
+            logging.error(f'Failed to receive SSH tunnel worker startup output: {e}')
+            _close_ssh_forward_subprocess(proc, connection, socket_address)
+            exit(1)
+
+        _forwards[ssh_config] = (str(host), int(port))
+        _forward_processes[ssh_config] = (proc, connection, socket_address)
     return _forwards[ssh_config]
+
+
+def _worker_main(socket_address: str, authkey_hex: str):
+    from multiprocessing.connection import Listener
+
+    try:
+        authkey = bytes.fromhex(authkey_hex)
+    except ValueError:
+        logging.error('Invalid SSH worker authkey payload.')
+        return 1
+
+    listener = Listener(socket_address, family='AF_UNIX', authkey=authkey)
+    connection: Connection | None = None
+    try:
+        connection = listener.accept()
+        ssh_config = connection.recv()
+        if not isinstance(ssh_config, dict):
+            logging.error('SSH worker expects the configuration payload to be a dict.')
+            return 1
+        _ssh_forward_process(connection, ssh_config)
+    finally:
+        if connection is not None:
+            connection.close()
+        listener.close()
+        _remove_unix_socket(socket_address)
+    return 0
 
 
 def get_forwarded_mongo_client(
@@ -230,3 +333,11 @@ def get_forwarded_mongo_client(
         **kwargs,
     )
     return client
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4 or sys.argv[1] != '--worker':
+        raise SystemExit(
+            'Usage: python -m seml.utils.ssh_forward --worker <socket_address> <authkey_hex>'
+        )
+    raise SystemExit(_worker_main(sys.argv[2], sys.argv[3]))

--- a/src/seml/utils/ssh_tunnel_worker.py
+++ b/src/seml/utils/ssh_tunnel_worker.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import sys
+import time
+from typing import TYPE_CHECKING, Any
+
+from seml.settings import SETTINGS
+
+if TYPE_CHECKING:
+    from multiprocessing.connection import Connection
+
+_STOP_COMMAND = 'stop'
+
+
+def retried_and_locked_ssh_port_forward(
+    retries_max: int = SETTINGS.SSH_FORWARD.RETRIES_MAX,
+    retries_delay: int = SETTINGS.SSH_FORWARD.RETRIES_DELAY,
+    lock_file: str = SETTINGS.SSH_FORWARD.LOCK_FILE,
+    lock_timeout: int = SETTINGS.SSH_FORWARD.LOCK_TIMEOUT,
+    **ssh_config,
+):
+    """
+    Attempt to establish an SSH tunnel with retries and a lock file to avoid parallel tunnel establishment.
+
+    Parameters
+    ----------
+    retries_max: int
+        Maximum number of retries to establish the tunnel.
+    retries_delay: float
+        Initial delay for exponential backoff.
+    lock_file: str
+        Path to the lock file.
+    lock_timeout: int
+        Timeout for acquiring the lock.
+    ssh_config: dict
+        Configuration for the SSH tunnel.
+
+    Returns
+    -------
+    server: SSHTunnelForwarder
+        The SSH tunnel server.
+    """
+    import random
+
+    from filelock import FileLock, Timeout
+    from sshtunnel import BaseSSHTunnelForwarderError, SSHTunnelForwarder
+
+    delay = retries_delay
+    error = None
+    # disable SSH forward messages
+    logging.getLogger('paramiko.transport').disabled = True
+    for _ in range(retries_max):
+        try:
+            lock = FileLock(lock_file, mode=0o666, timeout=lock_timeout)
+            with lock:
+                server = SSHTunnelForwarder(**ssh_config)
+                server.start()
+                if not server.tunnel_is_up[server.local_bind_address]:
+                    raise BaseSSHTunnelForwarderError()
+                return server
+        except Timeout as e:
+            error = e
+            logging.warning(f'Failed to aquire lock for ssh tunnel {lock_file}')
+        except BaseSSHTunnelForwarderError as e:
+            error = e
+            logging.warning(f'Retry establishing ssh tunnel in {delay} s')
+            # Jittered exponential retry
+            time.sleep(delay)
+            delay *= 2
+            delay += random.uniform(0, 1)
+
+    logging.error(f'Failed to establish ssh tunnel: {error}')
+    exit(1)
+
+
+def _remove_unix_socket(socket_address: str):
+    with contextlib.suppress(FileNotFoundError, OSError):
+        os.unlink(socket_address)
+
+
+def _ssh_forward_process(connection: Connection, ssh_config: dict[str, Any]):
+    """
+    Establish an SSH tunnel in a separate process. The process periodically checks if the tunnel is still up and
+    restarts it if it is not.
+
+    Parameters
+    ----------
+    connection: Connection
+        Connection carrying commands from the parent process.
+    ssh_config: dict
+        Configuration for the SSH tunnel.
+    """
+    server = retried_and_locked_ssh_port_forward(**ssh_config)
+    # We need to bind to the same local addresses
+    server._local_binds = server.local_bind_addresses
+    connection.send((str(server.local_bind_host), int(server.local_bind_port)))
+
+    while True:
+        # check if we should end the process
+        try:
+            command = None
+            if connection.poll(SETTINGS.SSH_FORWARD.HEALTH_CHECK_INTERVAL):
+                command = connection.recv()
+
+            if command == _STOP_COMMAND:
+                server.stop()
+                break
+
+            # Check for tunnel health
+            server.check_tunnels()
+            if not server.tunnel_is_up[server.local_bind_address]:
+                logging.warning('SSH tunnel was closed unexpectedly. Restarting.')
+                server.restart()
+        except KeyboardInterrupt:
+            server.stop()
+            break
+        except (EOFError, OSError):
+            server.stop()
+            break
+        except Exception as e:
+            logging.error(f'Error in SSH tunnel health check:\n{e}')
+            server.restart()
+
+
+def main(socket_address: str, authkey_hex: str):
+    from multiprocessing.connection import Listener
+
+    try:
+        authkey = bytes.fromhex(authkey_hex)
+    except ValueError:
+        logging.error('Invalid SSH worker authkey payload.')
+        return 1
+
+    listener = Listener(socket_address, family='AF_UNIX', authkey=authkey)
+    connection: Connection | None = None
+    try:
+        connection = listener.accept()
+        ssh_config = connection.recv()
+        if not isinstance(ssh_config, dict):
+            logging.error('SSH worker expects the configuration payload to be a dict.')
+            return 1
+        _ssh_forward_process(connection, ssh_config)
+    finally:
+        if connection is not None:
+            connection.close()
+        listener.close()
+        _remove_unix_socket(socket_address)
+    return 0
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4 or sys.argv[1] != '--worker':
+        raise SystemExit(
+            'Usage: python -m seml.utils.ssh_tunnel_worker --worker <socket_address> <authkey_hex>'
+        )
+    raise SystemExit(main(sys.argv[2], sys.argv[3]))

--- a/uv.lock
+++ b/uv.lock
@@ -1244,6 +1244,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.28.1" },
     { name = "rich", specifier = ">=13.0,<14.1" },
     { name = "sacred", specifier = ">=0.8.4" },
+    { name = "setuptools", specifier = "<81" },
     { name = "setuptools", specifier = ">=69.2.0" },
     { name = "sshtunnel", marker = "extra == 'ssh-forward'", specifier = ">=0.4.0" },
     { name = "typer", specifier = ">=0.12" },

--- a/uv.lock
+++ b/uv.lock
@@ -1205,6 +1205,13 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 
+[package.optional-dependencies]
+ssh-forward = [
+    { name = "filelock" },
+    { name = "paramiko" },
+    { name = "sshtunnel" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "filelock" },
@@ -1215,17 +1222,13 @@ dev = [
     { name = "sshtunnel" },
     { name = "tuna" },
 ]
-ssh-forward = [
-    { name = "filelock" },
-    { name = "paramiko" },
-    { name = "sshtunnel" },
-]
 
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0" },
     { name = "debugpy", specifier = ">=1.2.1" },
     { name = "deepdiff", specifier = ">=7.0.1" },
+    { name = "filelock", marker = "extra == 'ssh-forward'", specifier = ">=3.13.3" },
     { name = "gitignore-parser", specifier = ">=0.1.11" },
     { name = "importlib-resources", specifier = ">=5.7.0" },
     { name = "jsonpickle", specifier = ">=2.2" },
@@ -1235,16 +1238,19 @@ requires-dist = [
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "pandas", marker = "python_full_version < '3.13'", specifier = ">=2.2" },
     { name = "pandas", marker = "python_full_version >= '3.13'", specifier = ">=2.2.3" },
+    { name = "paramiko", marker = "extra == 'ssh-forward'", specifier = ">=3.0,<4.0" },
     { name = "pymongo", specifier = ">=4.1" },
     { name = "pyyaml", specifier = ">=5.1" },
     { name = "requests", specifier = ">=2.28.1" },
     { name = "rich", specifier = ">=13.0,<14.1" },
     { name = "sacred", specifier = ">=0.8.4" },
     { name = "setuptools", specifier = ">=69.2.0" },
+    { name = "sshtunnel", marker = "extra == 'ssh-forward'", specifier = ">=0.4.0" },
     { name = "typer", specifier = ">=0.12" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.10" },
     { name = "typing-extensions", marker = "python_full_version >= '3.13'", specifier = ">=4.12" },
 ]
+provides-extras = ["ssh-forward"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1255,11 +1261,6 @@ dev = [
     { name = "ruff", specifier = ">=0.6.1" },
     { name = "sshtunnel", specifier = ">=0.4.0" },
     { name = "tuna", specifier = ">=0.5.11" },
-]
-ssh-forward = [
-    { name = "filelock", specifier = ">=3.13.3" },
-    { name = "paramiko", specifier = ">=3.0,<4.0" },
-    { name = "sshtunnel", specifier = ">=0.4.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
The SSH forward tunnel used multiprocessing with the forkserver start method, which spawned worker processes and imported `__main__`. In practice, this caused every worker to re-execute the user's training script entry point, initialising JAX (and other frameworks) a second time in the background and silently claiming GPU memory for the lifetime of the job.


### What does this implement/fix?
The fix replaces the forkserver-based worker with a `subprocess.Popen` call that runs a dedicated, minimal worker module, communicating with the parent process over a socket instead of a multiprocessing queue. Because the worker module imports nothing from user code, the GPU memory leak is eliminated.

